### PR TITLE
Switch @minecraft/server to a peer dependency

### DIFF
--- a/change/@minecraft-math-41fcb2b6-6a4c-4706-be67-f34448120b1b.json
+++ b/change/@minecraft-math-41fcb2b6-6a4c-4706-be67-f34448120b1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Minor adjustment to dependencies, making @minecraft/server a peer instead of direct dependency",
+  "packageName": "@minecraft/math",
+  "email": "rlanda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/libraries/math/package.json
+++ b/libraries/math/package.json
@@ -1,29 +1,30 @@
 {
-  "name": "@minecraft/math",
-  "version": "1.0.1",
-  "author": "Raphael Landaverde (rlanda@microsoft.com)",
-  "description": "Math utilities for use with minecraft scripting modules",
-  "main": "lib/index.js",
-  "types": "lib/types/math-public.d.ts",
-  "scripts": {
-    "build": "just build",
-    "lint": "just lint",
-    "test": "just test",
-    "clean": "just clean"
-  },
-  "license": "MIT",
-  "files": [
-    "dist",
-    "lib",
-    "api-report"
-  ],
-  "dependencies": {
-    "@minecraft/server": "^1.6.0"
-  },
-  "devDependencies": {
-    "@minecraft/core-build-tasks": "*",
-    "@minecraft/tsconfig": "*",
-    "just-scripts": "^2.2.1",
-    "vitest": "^0.34.6"
-  }
+    "name": "@minecraft/math",
+    "version": "1.0.1",
+    "author": "Raphael Landaverde (rlanda@microsoft.com)",
+    "description": "Math utilities for use with minecraft scripting modules",
+    "main": "lib/index.js",
+    "types": "lib/types/math-public.d.ts",
+    "scripts": {
+        "build": "just build",
+        "lint": "just lint",
+        "test": "just test",
+        "clean": "just clean"
+    },
+    "license": "MIT",
+    "files": [
+        "dist",
+        "lib",
+        "api-report"
+    ],
+    "peerDependencies": {
+        "@minecraft/server": "^1.6.0"
+    },
+    "devDependencies": {
+        "@minecraft/server": "^1.6.0",
+        "@minecraft/core-build-tasks": "*",
+        "@minecraft/tsconfig": "*",
+        "just-scripts": "^2.2.1",
+        "vitest": "^0.34.6"
+    }
 }


### PR DESCRIPTION
It's more flexible for @minecraft/server to be a peer dependency as it then doesn't force the download of a specific version of types when using this package, and puts that instead on the pack author to select.