### PR TITLE
Support for source map files creation at different path.

### DIFF
--- a/change/@minecraft-core-build-tasks-c6268aa7-bcd4-469d-8ca7-224d1271babe.json
+++ b/change/@minecraft-core-build-tasks-c6268aa7-bcd4-469d-8ca7-224d1271babe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support for source map files creation at different path",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "frgarc@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/package.json
+++ b/tools/core-build-tasks/package.json
@@ -5,6 +5,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "author": "Raphael Landaverde (rlanda@microsoft.com)",
+  "contributors": [
+    {
+      "name": "Francisco Alejandro Garcia Cebada",
+      "email": "frgarc@mojang.com"
+    }
+  ],
   "scripts": {
     "build-tools": "just-scripts build-tools",
     "clean-tools": "just-scripts clean-tools",

--- a/tools/core-build-tasks/src/tasks/bundle.test.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.test.ts
@@ -7,6 +7,7 @@ import { BuildOptions, BuildResult } from 'esbuild';
 import path from 'path';
 
 function _createParameters(
+    sourcemap: boolean | 'linked' | 'inline' | 'external' | 'both' | undefined,
     outputFile: string,
     outputSourcemapPath: string | undefined
 ): {
@@ -17,7 +18,7 @@ function _createParameters(
         options: {
             entryPoint: '',
             outfile: outputFile,
-            sourcemap: true,
+            sourcemap: sourcemap,
             outputSourcemapPath: outputSourcemapPath,
         },
         buildResult: {
@@ -39,10 +40,11 @@ function _createParameters(
 }
 
 describe('postProcessOutputFiles with source map files at different path', () => {
-    it('Dictionary populated correctly', () => {
+    it('sourcemap `true` - Dictionary populated correctly', () => {
+        const sourcemap = true;
         const debugPath = path.resolve('./dist/debug');
         const outputFile = path.resolve('./dist/scripts/main.js');
-        const parameters = _createParameters(outputFile, debugPath);
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
         const expectedSourceMapDirectory = path.resolve('./dist/debug');
         const expectedOutputDirectory = path.resolve('./dist/scripts');
         const expectedOutputFilePath = outputFile;
@@ -66,13 +68,126 @@ describe('postProcessOutputFiles with source map files at different path', () =>
             expect(sourceMap.file).toBe(expectedSourceMapFile);
         }
     });
+    it('sourcemap `linked` - Dictionary populated correctly', () => {
+        const sourcemap = 'linked';
+        const debugPath = path.resolve('./dist/debug');
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/debug');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/debug/main.js.map');
+        const expectedSourceMappingURL = '\n//# sourceMappingURL=../debug/main.js.map\n';
+        const expectedSourceMapFile = '../scripts/main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `external` - Dictionary populated correctly', () => {
+        const sourcemap = 'external';
+        const debugPath = path.resolve('./dist/debug');
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/debug');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/debug/main.js.map');
+        const expectedSourceMappingURL = '';
+        const expectedSourceMapFile = '../scripts/main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `both` - Dictionary populated correctly', () => {
+        const sourcemap = 'both';
+        const debugPath = path.resolve('./dist/debug');
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/debug');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/debug/main.js.map');
+        const expectedSourceMappingURL = '';
+        const expectedSourceMapFile = '../scripts/main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `inline` - Dictionary populated correctly', () => {
+        const sourcemap = 'inline';
+        const debugPath = path.resolve('./dist/debug');
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/debug');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/debug/main.js.map');
+        const expectedSourceMappingURL = '';
+        const expectedSourceMapFile = '../scripts/main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
 });
 
 describe('postProcessOutputFiles with source map files at same path', () => {
-    it('Dictionary populated correctly using undefined', () => {
+    it('sourcemap `true` - Dictionary populated correctly using undefined', () => {
+        const sourcemap = true;
         const debugPath = undefined;
         const outputFile = path.resolve('./dist/scripts/main.js');
-        const parameters = _createParameters(outputFile, debugPath);
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
         const expectedSourceMapDirectory = path.resolve('./dist/scripts');
         const expectedOutputDirectory = path.resolve('./dist/scripts');
         const expectedOutputFilePath = outputFile;
@@ -96,15 +211,128 @@ describe('postProcessOutputFiles with source map files at same path', () => {
             expect(sourceMap.file).toBe(expectedSourceMapFile);
         }
     });
-    it('Dictionary populated correctly using same path explicitly', () => {
+    it('sourcemap `true` - Dictionary populated correctly using same path explicitly', () => {
+        const sourcemap = true;
         const debugPath = path.resolve('./dist/scripts');
         const outputFile = path.resolve('./dist/scripts/main.js');
-        const parameters = _createParameters(outputFile, debugPath);
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
         const expectedSourceMapDirectory = path.resolve('./dist/scripts');
         const expectedOutputDirectory = path.resolve('./dist/scripts');
         const expectedOutputFilePath = outputFile;
         const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
         const expectedSourceMappingURL = '\n//# sourceMappingURL=main.js.map\n';
+        const expectedSourceMapFile = 'main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `linked` - Dictionary populated correctly using undefined', () => {
+        const sourcemap = 'linked';
+        const debugPath = undefined;
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/scripts');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
+        const expectedSourceMappingURL = '\n//# sourceMappingURL=main.js.map\n';
+        const expectedSourceMapFile = 'main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `external` - Dictionary populated correctly using undefined', () => {
+        const sourcemap = 'external';
+        const debugPath = undefined;
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/scripts');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
+        const expectedSourceMappingURL = '';
+        const expectedSourceMapFile = 'main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `both` - Dictionary populated correctly using undefined', () => {
+        const sourcemap = 'both';
+        const debugPath = undefined;
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/scripts');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
+        const expectedSourceMappingURL = '';
+        const expectedSourceMapFile = 'main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('sourcemap `inline` - Dictionary populated correctly using undefined', () => {
+        const sourcemap = 'inline';
+        const debugPath = undefined;
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/scripts');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
+        const expectedSourceMappingURL = '';
         const expectedSourceMapFile = 'main.js';
 
         const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
@@ -126,9 +354,20 @@ describe('postProcessOutputFiles with source map files at same path', () => {
 });
 
 describe('postProcessOutputFiles with no files', () => {
-    it('Returns undefined', () => {
+    it('sourcemap `true` - Returns undefined', () => {
+        const sourcemap = true;
         const outputFile = path.resolve('./dist/scripts/main.js');
-        const parameters = _createParameters(outputFile, undefined);
+        const parameters = _createParameters(sourcemap, outputFile, undefined);
+        parameters.buildResult.outputFiles = undefined;
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeUndefined();
+    });
+    it('sourcemap `false` - Returns undefined', () => {
+        const sourcemap = false;
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(sourcemap, outputFile, undefined);
         parameters.buildResult.outputFiles = undefined;
 
         const result = postProcessOutputFiles(parameters.options, parameters.buildResult);

--- a/tools/core-build-tasks/src/tasks/bundle.test.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from 'vitest';
+import { BundleTaskParameters, postProcessOutputFiles } from './bundle';
+import { BuildOptions, BuildResult } from 'esbuild';
+import path from 'path';
+
+function _createParameters(
+    outputFile: string,
+    outputSourcemapPath: string | undefined
+): {
+    options: BundleTaskParameters;
+    buildResult: BuildResult<BuildOptions>;
+} {
+    return {
+        options: {
+            entryPoint: '',
+            outfile: outputFile,
+            sourcemap: true,
+            outputSourcemapPath: outputSourcemapPath,
+        },
+        buildResult: {
+            outputFiles: [
+                { path: outputFile, contents: new Uint8Array(), hash: '', text: '' },
+                {
+                    path: 'main.js.map',
+                    contents: new Uint8Array(),
+                    hash: '',
+                    text: '{"version":3,"sources":["../../scripts/main.ts"],"sourcesContent":[""],"mappings":";AAAA,SAAS,OAAO;","names":[]}',
+                },
+            ],
+            errors: [],
+            warnings: [],
+            metafile: { inputs: {}, outputs: {} },
+            mangleCache: {},
+        } as BuildResult<BuildOptions>,
+    };
+}
+
+describe('postProcessOutputFiles with source map files at different path', () => {
+    it('Dictionary populated correctly', async () => {
+        const debugPath = path.resolve('./dist/debug');
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/debug');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/debug/main.js.map');
+        const expectedSourceMappingURL = '\n//# sourceMappingURL=../debug/main.js.map\n';
+        const expectedSourceMapFile = '../scripts/main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+});
+
+describe('postProcessOutputFiles with source map files at same path', () => {
+    it('Dictionary populated correctly using undefined', async () => {
+        const debugPath = undefined;
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/scripts');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
+        const expectedSourceMappingURL = '\n//# sourceMappingURL=main.js.map\n';
+        const expectedSourceMapFile = 'main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+    it('Dictionary populated correctly using same path explicitly', async () => {
+        const debugPath = path.resolve('./dist/scripts');
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(outputFile, debugPath);
+        const expectedSourceMapDirectory = path.resolve('./dist/scripts');
+        const expectedOutputDirectory = path.resolve('./dist/scripts');
+        const expectedOutputFilePath = outputFile;
+        const expectedSourceMapFilePath = path.resolve('./dist/scripts/main.js.map');
+        const expectedSourceMappingURL = '\n//# sourceMappingURL=main.js.map\n';
+        const expectedSourceMapFile = 'main.js';
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeDefined();
+        if (result) {
+            expect(result.outputDirectory).toBe(expectedOutputDirectory);
+            expect(result.sourceMapDirectory).toBe(expectedSourceMapDirectory);
+            expect(Object.keys(result.generatedFiles).length).toBe(2);
+            expect(result.generatedFiles[expectedOutputFilePath]).toBeDefined();
+            expect(result.generatedFiles[expectedOutputFilePath]).toBe(expectedSourceMappingURL);
+            expect(result.generatedFiles[expectedSourceMapFilePath]).toBeDefined();
+            const sourceMap = JSON.parse(result.generatedFiles[expectedSourceMapFilePath]);
+            expect(sourceMap).toBeDefined();
+            expect(sourceMap.file).toBeDefined();
+            expect(sourceMap.file).toBe(expectedSourceMapFile);
+        }
+    });
+});
+
+describe('postProcessOutputFiles with no files', () => {
+    it('Returns undefined', async () => {
+        const outputFile = path.resolve('./dist/scripts/main.js');
+        const parameters = _createParameters(outputFile, undefined);
+        parameters.buildResult.outputFiles = undefined;
+
+        const result = postProcessOutputFiles(parameters.options, parameters.buildResult);
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/tools/core-build-tasks/src/tasks/bundle.test.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.test.ts
@@ -34,12 +34,12 @@ function _createParameters(
             warnings: [],
             metafile: { inputs: {}, outputs: {} },
             mangleCache: {},
-        } as BuildResult<BuildOptions>,
+        },
     };
 }
 
 describe('postProcessOutputFiles with source map files at different path', () => {
-    it('Dictionary populated correctly', async () => {
+    it('Dictionary populated correctly', () => {
         const debugPath = path.resolve('./dist/debug');
         const outputFile = path.resolve('./dist/scripts/main.js');
         const parameters = _createParameters(outputFile, debugPath);
@@ -69,7 +69,7 @@ describe('postProcessOutputFiles with source map files at different path', () =>
 });
 
 describe('postProcessOutputFiles with source map files at same path', () => {
-    it('Dictionary populated correctly using undefined', async () => {
+    it('Dictionary populated correctly using undefined', () => {
         const debugPath = undefined;
         const outputFile = path.resolve('./dist/scripts/main.js');
         const parameters = _createParameters(outputFile, debugPath);
@@ -96,7 +96,7 @@ describe('postProcessOutputFiles with source map files at same path', () => {
             expect(sourceMap.file).toBe(expectedSourceMapFile);
         }
     });
-    it('Dictionary populated correctly using same path explicitly', async () => {
+    it('Dictionary populated correctly using same path explicitly', () => {
         const debugPath = path.resolve('./dist/scripts');
         const outputFile = path.resolve('./dist/scripts/main.js');
         const parameters = _createParameters(outputFile, debugPath);
@@ -126,7 +126,7 @@ describe('postProcessOutputFiles with source map files at same path', () => {
 });
 
 describe('postProcessOutputFiles with no files', () => {
-    it('Returns undefined', async () => {
+    it('Returns undefined', () => {
         const outputFile = path.resolve('./dist/scripts/main.js');
         const parameters = _createParameters(outputFile, undefined);
         parameters.buildResult.outputFiles = undefined;

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -37,7 +37,7 @@ export type PostProcessOutputFilesResult = {
 function isRequiredToMakeAnyFileChange(
     sourcemap: boolean | 'linked' | 'inline' | 'external' | 'both' | undefined
 ): boolean {
-    return sourcemap === true || sourcemap === 'linked' || sourcemap === 'external' || sourcemap === 'both';
+    return sourcemap !== false && sourcemap !== 'inline';
 }
 
 function isRequiredToLinkJsFile(sourcemap: boolean | 'linked' | 'inline' | 'external' | 'both' | undefined): boolean {

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 import { parallel } from 'just-scripts';
-import esbuild from 'esbuild';
+import esbuild, { BuildResult, OutputFile } from 'esbuild';
+import fs from 'fs';
+import path from 'path';
+
+const MAP_EXTENSION = '.map';
 
 export type BundleTaskParameters = {
     /** Initial script to be evaluated for the build. Documentation: https://esbuild.github.io/api/#entry-points */
@@ -17,20 +21,88 @@ export type BundleTaskParameters = {
     /** The output file for the bundle. Documentation: https://esbuild.github.io/api/#outfile */
     outfile: string;
 
-    /** Flag to specify how to generate source map. Documentation: https://esbuild.github.io/api/#sourcemap */
-    sourcemap?: boolean | 'linked' | 'inline' | 'external' | 'both';
+    /** Flag to specify to generate a source map file.*/
+    sourcemap?: boolean;
+
+    /** The output path for the source map file. Only when sourcemap option is set to true. */
+    outputSourcemapPath?: string;
 };
 
+function linkSourceMaps(
+    sourceMapDirectory: string,
+    outputDirectory: string,
+    outputFiles: OutputFile[]
+): Map<string, string> {
+    const generatedFiles = new Map<string, string>();
+    outputFiles.forEach(element => {
+        if (element.path.endsWith(MAP_EXTENSION)) {
+            const parsedPath = path.parse(element.path);
+            const sourceMapFilePath = path.join(sourceMapDirectory, parsedPath.base);
+            const sourceMapContent = JSON.parse(element.text);
+
+            // Add JS file location.
+            sourceMapContent.file = path
+                .relative(sourceMapDirectory, path.join(outputDirectory, parsedPath.name))
+                .replace(/\\/g, '/');
+            generatedFiles.set(sourceMapFilePath, JSON.stringify(sourceMapContent));
+        } else {
+            // Link to the source map file.
+            const dir = path.parse(element.path).dir;
+            const targetSourceMap = path
+                .join(path.relative(dir, sourceMapDirectory), path.parse(element.path).base)
+                .replace(/\\/g, '/');
+            generatedFiles.set(
+                element.path,
+                element.text + `\n//# sourceMappingURL=${targetSourceMap}${MAP_EXTENSION}\n`
+            );
+        }
+    });
+
+    return generatedFiles;
+}
+
+function writeFiles(sourceMapDirectory: string, outputDirectory: string, generatedFiles: Map<string, string>) {
+    fs.mkdirSync(outputDirectory, { recursive: true });
+    if (sourceMapDirectory !== outputDirectory) {
+        fs.mkdirSync(sourceMapDirectory, { recursive: true });
+    }
+
+    for (const [path, content] of generatedFiles.entries()) {
+        fs.writeFileSync(path, content);
+    }
+}
+
 export function bundleTask(options: BundleTaskParameters): ReturnType<typeof parallel> {
-    return async () => {
-        return esbuild.build({
+    return () => {
+        const buildResult: BuildResult = esbuild.buildSync({
             entryPoints: [options.entryPoint],
             bundle: true,
             format: 'esm',
             minifyWhitespace: options.minifyWhitespace,
             outfile: options.outfile,
-            sourcemap: options.sourcemap,
+            sourcemap: options.sourcemap ? 'external' : false,
             external: options.external,
+            write: !options.sourcemap,
         });
+
+        if (buildResult.errors.length == 0) {
+            if (options.sourcemap) {
+                if (!buildResult.outputFiles) {
+                    process.exitCode = 1;
+                    return Promise.reject(new Error('Output files are not generated'));
+                }
+
+                const outputDirectory = path.parse(options.outfile).dir;
+                const sourceMapDirectory = path.resolve(options.outputSourcemapPath ?? outputDirectory);
+                const generatedFiles = linkSourceMaps(sourceMapDirectory, outputDirectory, buildResult.outputFiles);
+                writeFiles(sourceMapDirectory, outputDirectory, generatedFiles);
+            }
+
+            process.exitCode = 0;
+            return Promise.resolve();
+        }
+
+        process.exitCode = 1;
+        return Promise.reject(new Error(buildResult.errors.join('\n')));
     };
 }


### PR DESCRIPTION
### Description
- Adding parameter `outputSourcemapPath` to class `BundleTaskParameters`. If this parameter is provided the source map files are generated at this location.

### Guidance for review

Esbuild does not support to create source map files at different location. Following suggestion from the author is to switch the `sourcemap` flag to `external` and append the required `sourceMappingURL` comment manually to link the files.
Here are the details: https://github.com/evanw/esbuild/issues/2254