### PR TITLE
Change `/setBlock` to use command casing convention

### DIFF
--- a/change/eslint-plugin-minecraft-linting-ce20bfba-df62-44a8-b3e6-aaad8618fdb6.json
+++ b/change/eslint-plugin-minecraft-linting-ce20bfba-df62-44a8-b3e6-aaad8618fdb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update setBlock to setblock",
+  "packageName": "eslint-plugin-minecraft-linting",
+  "email": "thomas@gamemodeone.com",
+  "dependentChangeType": "patch"
+}

--- a/change/eslint-plugin-minecraft-linting-ce20bfba-df62-44a8-b3e6-aaad8618fdb6.json
+++ b/change/eslint-plugin-minecraft-linting-ce20bfba-df62-44a8-b3e6-aaad8618fdb6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update setBlock to setblock",
+  "comment": "Change setBlock command suggestion to use command casing convention.",
   "packageName": "eslint-plugin-minecraft-linting",
   "email": "thomas@gamemodeone.com",
   "dependentChangeType": "patch"

--- a/tools/eslint-plugin-minecraft-linting/src/Rules/AvoidUnnecessaryCommand.test.ts
+++ b/tools/eslint-plugin-minecraft-linting/src/Rules/AvoidUnnecessaryCommand.test.ts
@@ -52,12 +52,12 @@ describe('AvoidUnnecessaryCommand', () => {
             invalid: [
                 // Basic string cases
                 {
-                    code: `player.runCommand('/setBlock ~ ~ ~ grass');`,
+                    code: `player.runCommand('/setblock ~ ~ ~ grass');`,
                     errors: [
                         {
                             messageId: 'replaceWithScriptMethod',
                             data: {
-                                command: '/setBlock',
+                                command: '/setblock',
                                 module: '@minecraft/server',
                                 api: 'Block.setPermutation',
                                 message:

--- a/tools/eslint-plugin-minecraft-linting/src/Rules/AvoidUnnecessaryCommand.ts
+++ b/tools/eslint-plugin-minecraft-linting/src/Rules/AvoidUnnecessaryCommand.ts
@@ -33,7 +33,7 @@ function isApiRecommendation(recommendation: ScriptRecommendation): recommendati
 
 const ScriptRecommendations: Map<string, ApiScriptRecommendation | ClassScriptRecommendation> = new Map([
     [
-        '/setBlock',
+        '/setblock',
         {
             module: '@minecraft/server',
             message:


### PR DESCRIPTION
Resolves #17. The check for setblock looks for /setBlock, which is not the convention for command casing. Reference documentation lists the command as `/setblock`. 

- Updated command
- Updated command tests