### PR TITLE
Add repo link to core-build-tasks and linting plugin

### DIFF
--- a/change/@minecraft-core-build-tasks-ca4bfd94-52b9-420c-a768-4605061df597.json
+++ b/change/@minecraft-core-build-tasks-ca4bfd94-52b9-420c-a768-4605061df597.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added repo link to package.json",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "thomas@gamemodeone.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@minecraft-math-fbdd8ce9-9bb3-4c06-a932-fe20d876d60e.json
+++ b/change/@minecraft-math-fbdd8ce9-9bb3-4c06-a932-fe20d876d60e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added monorepo support to package.json",
+  "packageName": "@minecraft/math",
+  "email": "thomas@gamemodeone.com",
+  "dependentChangeType": "patch"
+}

--- a/change/eslint-plugin-minecraft-linting-9bb5a3db-f43a-40f9-97fc-5e1bef72357f.json
+++ b/change/eslint-plugin-minecraft-linting-9bb5a3db-f43a-40f9-97fc-5e1bef72357f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added repo link to package.json",
+  "packageName": "eslint-plugin-minecraft-linting",
+  "email": "thomas@gamemodeone.com",
+  "dependentChangeType": "patch"
+}

--- a/libraries/math/package.json
+++ b/libraries/math/package.json
@@ -13,7 +13,8 @@
   "types": "lib/types/math-public.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Mojang/minecraft-scripting-libraries.git"
+    "url": "https://github.com/Mojang/minecraft-scripting-libraries.git",
+    "directory": "libraries/math"
   },
   "scripts": {
     "build": "just build",

--- a/tools/core-build-tasks/package.json
+++ b/tools/core-build-tasks/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Mojang/minecraft-scripting-libraries.git",
+    "url": "https://github.com/Mojang/minecraft-scripting-libraries.git",
     "directory": "tools/core-build-tasks"
   },
   "scripts": {

--- a/tools/core-build-tasks/package.json
+++ b/tools/core-build-tasks/package.json
@@ -11,6 +11,11 @@
       "email": "frgarc@mojang.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mojang/minecraft-scripting-libraries.git",
+    "directory": "tools/core-build-tasks"
+  },
   "scripts": {
     "build-tools": "just-scripts build-tools",
     "clean-tools": "just-scripts clean-tools",

--- a/tools/eslint-plugin-minecraft-linting/package.json
+++ b/tools/eslint-plugin-minecraft-linting/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Mojang/minecraft-scripting-libraries.git",
+    "url": "https://github.com/Mojang/minecraft-scripting-libraries.git",
     "directory": "tools/eslint-plugin-minecraft-linting"
   },
   "scripts": {

--- a/tools/eslint-plugin-minecraft-linting/package.json
+++ b/tools/eslint-plugin-minecraft-linting/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mojang/minecraft-scripting-libraries.git",
+    "directory": "tools/eslint-plugin-minecraft-linting"
+  },
   "scripts": {
     "build": "just-scripts build",
     "lint": "just-scripts lint",


### PR DESCRIPTION
Noticed the repo link was missing from `eslint-plugin-minecraft-linting` and `eslint-plugin-minecraft-linting`. 
This change should add the "Repository" section on npmjs! Also added the `directory` value to add support for the monorepo!
