### PR TITLE
Add support for spaces in the directory path when getting the eslint config file

### DIFF
--- a/change/@minecraft-core-build-tasks-80fb532f-c7a5-40c4-a847-316ca6e13b30.json
+++ b/change/@minecraft-core-build-tasks-80fb532f-c7a5-40c4-a847-316ca6e13b30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for spaces in the path to the eslint config file",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "thomas@gamemodeone.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/src/tasks/coreLint.ts
+++ b/tools/core-build-tasks/src/tasks/coreLint.ts
@@ -31,7 +31,7 @@ function eslintTask(files: string[], fix?: boolean): TaskFunction {
             process.env['ESLINT_USE_FLAT_CONFIG'] = FLAT_CONFIG_FILES.some(file => configFilePath.endsWith(file))
                 ? 'true'
                 : 'false';
-            const cmd = ['eslint', ...files, '--config', configFilePath, ...(fix ? ['--fix'] : []), '--color'].join(
+            const cmd = ['eslint', ...files, '--config', `"${configFilePath}"`, ...(fix ? ['--fix'] : []), '--color'].join(
                 ' '
             );
             logger.info(`Running command: ${cmd}`);


### PR DESCRIPTION
Resolves #24 by wrapping `configFilePath` in "". Adding support for parent directories which have spaces in their name. Such as `D:\2. Repos\