### PR TITLE
Add `clean` support for `Custom` deployment  paths

### DIFF
--- a/tools/core-build-tasks/src/tasks/cleanCollateral.ts
+++ b/tools/core-build-tasks/src/tasks/cleanCollateral.ts
@@ -5,13 +5,32 @@ import * as fs from 'fs';
 import * as Path from 'path';
 import rimraf from 'rimraf';
 import { getOrThrowFromProcess } from './helpers/getOrThrowFromProcess';
+import { getGameDeploymentRootPaths } from './helpers/getGameDeploymentRootPaths';
 
+/** @deprecated Use {@link getStandardCleanPaths} instead of {@link STANDARD_CLEAN_PATHS} */
 export const STANDARD_CLEAN_PATHS = [
     'LOCALAPPDATA/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/development_behavior_packs/PROJECT_NAME',
     'LOCALAPPDATA/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/development_resource_packs/PROJECT_NAME',
     'LOCALAPPDATA/Packages/Microsoft.MinecraftWindowsBeta_8wekyb3d8bbwe/LocalState/games/com.mojang/development_behavior_packs/PROJECT_NAME',
     'LOCALAPPDATA/Packages/Microsoft.MinecraftWindowsBeta_8wekyb3d8bbwe/LocalState/games/com.mojang/development_resource_packs/PROJECT_NAME',
 ];
+
+export function getStandardCleanPaths() {
+    const projectName = getOrThrowFromProcess('PROJECT_NAME');
+    const results = Object.values(getGameDeploymentRootPaths())
+        .filter(rootPath => rootPath !== undefined)
+        .flatMap(rootPath => [
+            Path.resolve(rootPath, 'development_behavior_packs', projectName),
+            Path.resolve(rootPath, 'development_resource_packs', projectName),
+        ]);
+
+    if (results.length === 0) {
+        // Fallback logic
+        return STANDARD_CLEAN_PATHS;
+    }
+
+    return results;
+}
 
 /**
  * Cleans the specified outputs. Outputs could be either folders or files. Has support for the following variable replacements


### PR DESCRIPTION
The current implementation of `STANDARD_CLEAN_PATHS` does not have support for the `CUSTOM_DEPLOYMENT_PATH` environment variable which is used when `MINECRAFT_PRODUCT="Custom"`. This change switches the logic to use the existing `getGameDeploymentRootPaths` helper method to better generate the clean paths.

This change makes `clean` work out of the box on linux, as shown here:

```shell
chaws@pc:~/dev/mc/bedrock-sample$ pnpm local-deploy

> bedrock-sample@1.0.0 local-deploy /home/chaws/dev/mc/bedrock-sample
> just-scripts local-deploy

[9:31:06 PM] ■ started 'local-deploy'
[9:31:06 PM] ■ started 'clean-local'
Cleaning temp
Cleaning lib
Cleaning dist
[9:31:06 PM] ■ finished 'clean-local' in 0s
[9:31:06 PM] ■ started 'build'
[9:31:06 PM] ■ started 'typescript'
[9:31:06 PM] ■ Running /home/chaws/dev/mc/bedrock-sample/node_modules/typescript/lib/tsc.js with /home/chaws/dev/mc/bedrock-sample/tsconfig.json
[9:31:06 PM] ■ Executing: "/home/chaws/.local/share/pnpm/nodejs/20.12.0/bin/node" "/home/chaws/dev/mc/bedrock-sample/node_modules/typescript/lib/tsc.js" --project "/home/chaws/dev/mc/bedrock-sample/tsconfig.json"
[9:31:07 PM] ■ finished 'typescript' in 0.73s
[9:31:07 PM] ■ started 'bundle'
[9:31:07 PM] ■ finished 'bundle' in 0.07s
[9:31:07 PM] ■ finished 'build' in 0.8s
[9:31:07 PM] ■ started 'package'
[9:31:07 PM] ■ started 'clean-collateral'
Proceeding without APPDATA on this platform. File copy will fail if APPDATA is required.
Proceeding without LOCALAPPDATA on this platform. File copy will fail if LOCALAPPDATA is required.
Cleaning directory /home/chaws/.local/share/mcpelauncher/games/com.mojang/development_behavior_packs/bedrock_sample.
Cleaning directory /home/chaws/.local/share/mcpelauncher/games/com.mojang/development_resource_packs/bedrock_sample.
[9:31:07 PM] ■ finished 'clean-collateral' in 0.01s
[9:31:07 PM] ■ started 'copyArtifacts'
Copying folder /home/chaws/dev/mc/bedrock-sample/behavior_packs/bedrock_sample to /home/chaws/.local/share/mcpelauncher/games/com.mojang/development_behavior_packs/bedrock_sample
Copying folder /home/chaws/dev/mc/bedrock-sample/dist/scripts to /home/chaws/.local/share/mcpelauncher/games/com.mojang/development_behavior_packs/bedrock_sample/scripts
Copying folder /home/chaws/dev/mc/bedrock-sample/resource_packs/bedrock_sample to /home/chaws/.local/share/mcpelauncher/games/com.mojang/development_resource_packs/bedrock_sample
[9:31:07 PM] ■ finished 'copyArtifacts' in 0.01s
[9:31:07 PM] ■ finished 'package' in 0.01s
[9:31:07 PM] ■ finished 'local-deploy' in 0.83s
```