### PR TITLE
Synchronize beachball state with publish NPM packages

### DIFF
--- a/change/@minecraft-core-build-tasks-4bacd51b-c51c-4c07-a499-444b4e8eed62.json
+++ b/change/@minecraft-core-build-tasks-4bacd51b-c51c-4c07-a499-444b4e8eed62.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync packages after failed publish",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "rlanda@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@minecraft-math-63d5ee8e-39a1-49c4-8598-afb145cd236a.json
+++ b/change/@minecraft-math-63d5ee8e-39a1-49c4-8598-afb145cd236a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync packages after failed publish",
+  "packageName": "@minecraft/math",
+  "email": "rlanda@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/libraries/math/package.json
+++ b/libraries/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minecraft/math",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Raphael Landaverde (rlanda@microsoft.com)",
   "contributors": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         },
         "libraries/math": {
             "name": "@minecraft/math",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "license": "MIT",
             "devDependencies": {
                 "@minecraft/core-build-tasks": "*",
@@ -6090,7 +6090,7 @@
         },
         "tools/core-build-tasks": {
             "name": "@minecraft/core-build-tasks",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dependencies": {
                 "@microsoft/api-extractor": "^7.38.3",
                 "@rushstack/node-core-library": "^3.59.6",

--- a/tools/core-build-tasks/package.json
+++ b/tools/core-build-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minecraft/core-build-tasks",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Common build tasks used for minecraft-scripting-libraries",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Repo state and NPM became out of sync during a PAT rotation. This is correcting the state.