### PR TITLE
Tweak tsconfig so it's friendly to commonjs alongside ESM

### DIFF
--- a/change/@minecraft-core-build-tasks-e51dbed2-f9e3-40a3-abd9-3813a356ec3b.json
+++ b/change/@minecraft-core-build-tasks-e51dbed2-f9e3-40a3-abd9-3813a356ec3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Tweak tsconfig so it's friendly to commonjs alongside ESM",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "rlanda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@minecraft-math-e81ec011-0c50-4078-bc9b-d74ddc549756.json
+++ b/change/@minecraft-math-e81ec011-0c50-4078-bc9b-d74ddc549756.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tweak tsconfig so it's friendly to commonjs alongside ESM",
+  "packageName": "@minecraft/math",
+  "email": "rlanda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/libraries/math/tsconfig.json
+++ b/libraries/math/tsconfig.json
@@ -4,6 +4,8 @@
     "exclude": ["dist", "build", "node_modules"],
     "compilerOptions": {
         "outDir": "lib",
-        "declarationDir": "temp/types"
+        "declarationDir": "temp/types",
+        "module": "NodeNext",
+        "moduleResolution": "nodenext"
     }
 }

--- a/libraries/math/tsconfig.json
+++ b/libraries/math/tsconfig.json
@@ -5,7 +5,7 @@
     "compilerOptions": {
         "outDir": "lib",
         "declarationDir": "temp/types",
-        "module": "NodeNext",
-        "moduleResolution": "nodenext"
+        "module": "Node16",
+        "moduleResolution": "node16"
     }
 }

--- a/tools/core-build-tasks/package.json
+++ b/tools/core-build-tasks/package.json
@@ -1,49 +1,55 @@
 {
-  "name": "@minecraft/core-build-tasks",
-  "version": "1.1.7",
-  "description": "Common build tasks used for minecraft-scripting-libraries",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "author": "Raphael Landaverde (rlanda@microsoft.com)",
-  "contributors": [
-    {
-      "name": "Francisco Alejandro Garcia Cebada",
-      "email": "frgarc@mojang.com"
+    "name": "@minecraft/core-build-tasks",
+    "version": "1.1.7",
+    "description": "Common build tasks used for minecraft-scripting-libraries",
+    "main": "lib/index.js",
+    "exports": {
+        ".": {
+            "import": "./lib/index.js",
+            "require": "./lib/index.js"
+        }
+    },
+    "types": "lib/index.d.ts",
+    "author": "Raphael Landaverde (rlanda@microsoft.com)",
+    "contributors": [
+        {
+            "name": "Francisco Alejandro Garcia Cebada",
+            "email": "frgarc@mojang.com"
+        }
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Mojang/minecraft-scripting-libraries.git",
+        "directory": "tools/core-build-tasks"
+    },
+    "scripts": {
+        "build-tools": "just-scripts build-tools",
+        "clean-tools": "just-scripts clean-tools",
+        "lint": "just-scripts lint",
+        "test": "just-scripts test"
+    },
+    "files": [
+        "lib"
+    ],
+    "dependencies": {
+        "@rushstack/node-core-library": "^3.59.6",
+        "@microsoft/api-extractor": "^7.38.3",
+        "esbuild": "^0.20.1",
+        "dotenv": "^16.4.5",
+        "just-scripts": "^2.3.2",
+        "prettier": "^2.8.2",
+        "rimraf": "^3.0.2",
+        "vitest": "^0.34.6",
+        "zip-lib": "^0.7.3"
+    },
+    "devDependencies": {
+        "@types/node": "^14.0.0 || ^16.0.0 || ^18.0.0",
+        "@types/rimraf": "^3.0.2",
+        "@typescript-eslint/parser": "^7.2.0",
+        "eslint": "^8.53.0",
+        "ts-node": "^10.9.1",
+        "tsconfig": "*",
+        "typescript": "^5.2.2",
+        "webpack": "^5.86.0"
     }
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Mojang/minecraft-scripting-libraries.git",
-    "directory": "tools/core-build-tasks"
-  },
-  "scripts": {
-    "build-tools": "just-scripts build-tools",
-    "clean-tools": "just-scripts clean-tools",
-    "lint": "just-scripts lint",
-    "test": "just-scripts test"
-  },
-  "files": [
-    "lib"
-  ],
-  "dependencies": {
-    "@rushstack/node-core-library": "^3.59.6",
-    "@microsoft/api-extractor": "^7.38.3",
-    "esbuild": "^0.20.1",
-    "dotenv": "^16.4.5",
-    "just-scripts": "^2.3.2",
-    "prettier": "^2.8.2",
-    "rimraf": "^3.0.2",
-    "vitest": "^0.34.6",
-    "zip-lib": "^0.7.3"
-  },
-  "devDependencies": {
-    "@types/node": "^14.0.0 || ^16.0.0 || ^18.0.0",
-    "@types/rimraf": "^3.0.2",
-    "@typescript-eslint/parser": "^7.2.0",
-    "eslint": "^8.53.0",
-    "ts-node": "^10.9.1",
-    "tsconfig": "*",
-    "typescript": "^5.2.2",
-    "webpack": "^5.86.0"
-  }
 }

--- a/tools/core-build-tasks/tsconfig.json
+++ b/tools/core-build-tasks/tsconfig.json
@@ -4,7 +4,7 @@
     "exclude": ["dist", "build", "node_modules"],
     "compilerOptions": {
         "outDir": "lib",
-        "module": "NodeNext",
-        "moduleResolution": "nodenext"
+        "module": "Node16",
+        "moduleResolution": "node16"
     }
 }

--- a/tools/core-build-tasks/tsconfig.json
+++ b/tools/core-build-tasks/tsconfig.json
@@ -3,6 +3,8 @@
     "include": ["src/**/*"],
     "exclude": ["dist", "build", "node_modules"],
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "module": "NodeNext",
+        "moduleResolution": "nodenext"
     }
 }

--- a/tools/tsconfig/base.json
+++ b/tools/tsconfig/base.json
@@ -8,7 +8,6 @@
         "forceConsistentCasingInFileNames": true,
         "inlineSources": false,
         "isolatedModules": true,
-        "moduleResolution": "bundler",
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "preserveWatchOutput": true,
@@ -16,7 +15,6 @@
         "strict": true,
         "sourceMap": true,
         "lib": ["ES2020"],
-        "module": "ES2020",
         "target": "ES2020"
     },
     "exclude": ["node_modules"]


### PR DESCRIPTION
When ingested in tooling, the build tasks should support commonjs since they have `.js` extension and often are treated as CommonJS even when ESM is supported. The bundler setting in tsconfig was blanket applied which often just left standard import/export statements.