### PR TITLE
Fix: Make cleanTask synchronous

### DIFF
--- a/change/@minecraft-core-build-tasks-5a859695-4774-4105-a41c-b53667794f29.json
+++ b/change/@minecraft-core-build-tasks-5a859695-4774-4105-a41c-b53667794f29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: Make cleanTask synchronous This is to prevent it removing files when you 'copyFiles' to the same path directly after. This happens when using 'updateWorldTask' 'cleanCollateralTask' also is synchronous",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "maescool@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/src/tasks/clean.ts
+++ b/tools/core-build-tasks/src/tasks/clean.ts
@@ -9,10 +9,12 @@ export const DEFAULT_CLEAN_DIRECTORIES = ['temp', 'lib', 'dist'];
 export function cleanTask(dirs: string[]) {
     return () => {
         for (const dir of dirs) {
-            console.log(`Cleaning ${dir}`);
-            rimraf(path.resolve(process.cwd(), dir), () => {
-                // no-op on unable to clean
-            });
+            try {
+                console.log(`Cleaning ${dir}`);
+                rimraf.sync(path.resolve(process.cwd(), dir));
+            } catch (_: unknown) {
+                // File or directory did not exist, so we no-op
+            }
         }
     };
 }


### PR DESCRIPTION
This is to prevent it removing files when you 'copyFiles' to the same path directly after. 
This happens when using 'updateWorldTask'
'cleanCollateralTask' also is synchronous