### PR TITLE
Make publishRelease task publish a real release instead of a draft

### DIFF
--- a/change/@minecraft-core-build-tasks-6fe063c8-9a02-4b81-bcc2-f22aa0dbcda9.json
+++ b/change/@minecraft-core-build-tasks-6fe063c8-9a02-4b81-bcc2-f22aa0dbcda9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accidentally made the release a draft by default, fixed that",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "rlanda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/src/tasks/publishRelease.ts
+++ b/tools/core-build-tasks/src/tasks/publishRelease.ts
@@ -72,7 +72,7 @@ export function publishReleaseTask(config: PublishReleaseTaskConfig) {
             tag_name: tagName,
             name: `${name} ${publishedVersion}`,
             body,
-            draft: true,
+            draft: false,
             prerelease: false,
             generate_release_notes: false,
             headers: {


### PR DESCRIPTION
Left it as a draft during testing. I did not make this configurable for now, since the use case for it being configurable seemed pretty narrow, but open to changing it.