### PR TITLE
Fix Failed Publish for @minecraft/math 2.1.0

### DIFF
--- a/change/@minecraft-math-a0e5e874-12d3-460f-8ff5-0cfcd06a2e9d.json
+++ b/change/@minecraft-math-a0e5e874-12d3-460f-8ff5-0cfcd06a2e9d.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added constants VECTOR3_HALF and VECTOR3_NEGATIVE_ONE",
-  "packageName": "@minecraft/math",
-  "email": "alexander.denford@skyboxlabs.com",
-  "dependentChangeType": "patch"
-}

--- a/libraries/math/CHANGELOG.json
+++ b/libraries/math/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@minecraft/math",
   "entries": [
     {
+      "date": "Wed, 12 Feb 2025 23:03:05 GMT",
+      "version": "2.1.0",
+      "tag": "@minecraft/math_v2.1.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "alexander.denford@skyboxlabs.com",
+            "package": "@minecraft/math",
+            "commit": "b56d6fed1cf9c84c5dfae3f50714de3dca091c28",
+            "comment": "Added constants VECTOR3_HALF and VECTOR3_NEGATIVE_ONE"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 09 Jan 2025 19:25:04 GMT",
       "version": "2.0.0",
       "tag": "@minecraft/math_v2.0.0",

--- a/libraries/math/CHANGELOG.md
+++ b/libraries/math/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @minecraft/math
 
-<!-- This log was last generated on Thu, 09 Jan 2025 19:25:04 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 12 Feb 2025 23:03:05 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 2.1.0
+
+Wed, 12 Feb 2025 23:03:05 GMT
+
+### Minor changes
+
+- Added constants VECTOR3_HALF and VECTOR3_NEGATIVE_ONE (alexander.denford@skyboxlabs.com)
 
 ## 2.0.0
 

--- a/libraries/math/package.json
+++ b/libraries/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minecraft/math",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "Raphael Landaverde (rlanda@microsoft.com)",
   "contributors": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         },
         "libraries/math": {
             "name": "@minecraft/math",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@minecraft/core-build-tasks": "*",


### PR DESCRIPTION
Occurred due to a token issue that has since been resolved.