### PR TITLE
Add dropLabels to BundleTaskParameters to strip out labelled statements

### DIFF
--- a/change/@minecraft-core-build-tasks-84f4d067-bb6d-40b7-a6b6-fd47a7572e76.json
+++ b/change/@minecraft-core-build-tasks-84f4d067-bb6d-40b7-a6b6-fd47a7572e76.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Bundle task will now strip out dev labels if its a production build",
+  "comment": "Bundle tasks parameters can now take in dropLabels to strip out certain labelled statements.",
   "packageName": "@minecraft/core-build-tasks",
   "email": "mike.demone@skyboxlabs.com",
   "dependentChangeType": "patch"

--- a/change/@minecraft-core-build-tasks-84f4d067-bb6d-40b7-a6b6-fd47a7572e76.json
+++ b/change/@minecraft-core-build-tasks-84f4d067-bb6d-40b7-a6b6-fd47a7572e76.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Bundle task will now strip out dev labels if its a production build",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "mike.demone@skyboxlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { argv, parallel } from 'just-scripts';
+import { parallel } from 'just-scripts';
 import esbuild, { BuildResult, OutputFile } from 'esbuild';
 import fs from 'fs';
 import path from 'path';

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { parallel } from 'just-scripts';
+import { argv, parallel } from 'just-scripts';
 import esbuild, { BuildResult, OutputFile } from 'esbuild';
 import fs from 'fs';
 import path from 'path';
@@ -26,6 +26,9 @@ export type BundleTaskParameters = {
 
     /** The output path for the source map file. Ignored if sourcemap is false or 'inline'. */
     outputSourcemapPath?: string;
+
+    /** If this is a production build, all statements labelled with "dev:" will be stripped from the build. Useful for stripping out development specific code. */
+    productionBuild?: boolean;
 };
 
 export type PostProcessOutputFilesResult = {
@@ -115,6 +118,7 @@ export function bundleTask(options: BundleTaskParameters): ReturnType<typeof par
             sourcemap: isRequiredToLinkJs ? 'external' : options.sourcemap,
             external: options.external,
             write: !isRequiredToMakeChanges,
+            dropLabels: options.productionBuild ? ['dev'] : undefined
         });
 
         if (buildResult.errors.length === 0) {

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -118,7 +118,7 @@ export function bundleTask(options: BundleTaskParameters): ReturnType<typeof par
             sourcemap: isRequiredToLinkJs ? 'external' : options.sourcemap,
             external: options.external,
             write: !isRequiredToMakeChanges,
-            dropLabels: options.productionBuild ? ['dev'] : undefined
+            dropLabels: options.productionBuild ? ['dev'] : undefined,
         });
 
         if (buildResult.errors.length === 0) {

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -27,8 +27,8 @@ export type BundleTaskParameters = {
     /** The output path for the source map file. Ignored if sourcemap is false or 'inline'. */
     outputSourcemapPath?: string;
 
-    /** If this is a production build, all statements labelled with "dev:" will be stripped from the build. Useful for stripping out development specific code. */
-    productionBuild?: boolean;
+    /** Strip out statements with these labels. Documentation: https://esbuild.github.io/api/#drop-labels */
+    dropLabels?: string[];
 };
 
 export type PostProcessOutputFilesResult = {
@@ -118,7 +118,7 @@ export function bundleTask(options: BundleTaskParameters): ReturnType<typeof par
             sourcemap: isRequiredToLinkJs ? 'external' : options.sourcemap,
             external: options.external,
             write: !isRequiredToMakeChanges,
-            dropLabels: options.productionBuild ? ['dev'] : undefined,
+            dropLabels: options.dropLabels,
         });
 
         if (buildResult.errors.length === 0) {


### PR DESCRIPTION
This PR adds a `dropLabels` field to the `BundleTaskParameters` interface so packages can strip out certain labelled statements.

#### Example
If you set `dropLabels` to `['dev']` and your TS looks like this:
```TS
function main(): void {
    dev: if (world.isEditorWorld) {
      // Do development specific things
    }
}
```
The that if statement will be removed from the resulting JS. 