### PR TITLE
Added alias option to BundleTaskParameters

### DIFF
--- a/change/@minecraft-core-build-tasks-f17d58d2-2af8-40b5-8df6-5fa79555991c.json
+++ b/change/@minecraft-core-build-tasks-f17d58d2-2af8-40b5-8df6-5fa79555991c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added alias option to BundleTaskParameters",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "jake@xbox.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/src/tasks/bundle.ts
+++ b/tools/core-build-tasks/src/tasks/bundle.ts
@@ -29,6 +29,9 @@ export type BundleTaskParameters = {
 
     /** Strip out statements with these labels. Documentation: https://esbuild.github.io/api/#drop-labels */
     dropLabels?: string[];
+
+    /** This feature lets you substitute one package (key) for another (value) when bundling. */
+    alias?: Record<string, string>;
 };
 
 export type PostProcessOutputFilesResult = {
@@ -119,6 +122,7 @@ export function bundleTask(options: BundleTaskParameters): ReturnType<typeof par
             external: options.external,
             write: !isRequiredToMakeChanges,
             dropLabels: options.dropLabels,
+            alias: options.alias,
         });
 
         if (buildResult.errors.length === 0) {


### PR DESCRIPTION
I'd like this for redirecting certain native imports in some scenarios.