### PR TITLE
Checkout ref before doing beachball checks

### DIFF
--- a/.github/workflows/dependabot-beachball.yml
+++ b/.github/workflows/dependabot-beachball.yml
@@ -12,6 +12,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
This ensures we aren't in a detached state for the commit.