### PR TITLE
Fix api-docs-generator removeDuplicateVariantTypes filter to allow variants with multiple arrays

### DIFF
--- a/change/@minecraft-api-docs-generator-c0998d04-b86d-4bc7-be31-58a0c0ca5ff7.json
+++ b/change/@minecraft-api-docs-generator-c0998d04-b86d-4bc7-be31-58a0c0ca5ff7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix docs generator removeDuplicateVariantTypes filter for variants with multiple arrays",
+  "packageName": "@minecraft/api-docs-generator",
+  "email": "zachary.campbell@skyboxlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/api-docs-generator-test-snapshots/test/variants/__snapshots__/variants.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/variants/__snapshots__/variants.spec.ts.snap
@@ -44,6 +44,7 @@ Notes:
 
 ## Methods
 - [exampleMethod](#examplemethod)
+- [methodWithVariantOfArrays](#methodwithvariantofarrays)
 
 ### **exampleMethod**
 \`
@@ -53,6 +54,19 @@ exampleMethod(arg1: (arg0: number) => ((arg0: number) => (number | string) | str
 #### **Parameters**
 - **arg1**: (arg0: *number*) => ((arg0: *number*) => (*number* | *string*) | *string*)
 - **arg2**: *number*
+  
+Notes:
+- This function can't be called in read-only mode.
+
+### **methodWithVariantOfArrays**
+\`
+methodWithVariantOfArrays(arrays: number[] | string[]): boolean
+\`
+
+#### **Parameters**
+- **arrays**: *number*[] | *string*[]
+
+**Returns** *boolean*
   
 Notes:
 - This function can't be called in read-only mode.
@@ -131,6 +145,12 @@ export class ExampleClass {
      *
      */
     exampleMethod(arg1: (arg0: number) => (arg0: number) => (number | string) | string, arg2: number): void;
+    /**
+     * @remarks
+     * This function can't be called in read-only mode.
+     *
+     */
+    methodWithVariantOfArrays(arrays: number[] | string[]): boolean;
 }
 "
 `;

--- a/tools/api-docs-generator-test-snapshots/test/variants/input/test-module.json
+++ b/tools/api-docs-generator-test-snapshots/test/variants/input/test-module.json
@@ -85,6 +85,49 @@
             "name": "undefined",
             "valid_range": null
           }
+        },
+        {
+          "arguments": [
+            {
+              "details": null,
+              "name": "arrays",
+              "type": {
+                "is_bind_type": false,
+                "is_errorable": false,
+                "name": "variant",
+                "variant_types": [
+                  {
+                    "element_type": {
+                      "is_bind_type": false,
+                      "is_errorable": false,
+                      "name": "number"
+                    },
+                    "is_bind_type": false,
+                    "is_errorable": false,
+                    "name": "array"
+                  },
+                  {
+                    "element_type": {
+                      "is_bind_type": false,
+                      "is_errorable": false,
+                      "name": "string"
+                    },
+                    "is_bind_type": false,
+                    "is_errorable": false,
+                    "name": "array"
+                  }
+                ]
+              }
+            }
+          ],
+          "is_constructor": false,
+          "is_static": false,
+          "name": "methodWithVariantOfArrays",
+          "return_type": {
+            "is_bind_type": false,
+            "is_errorable": false,
+            "name": "boolean"
+          }
         }
       ],
       "name": "ExampleClass",

--- a/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
+++ b/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
@@ -176,7 +176,11 @@ function removeDuplicateVariantTypes(releases: MinecraftRelease[]) {
                     return (
                         index ===
                         self.findIndex(value => {
-                            return value.name === item.name;
+                            return item.name === 'array'
+                                ? value.element_type.name === item.element_type.name
+                                : item.name === 'optional'
+                                  ? value.optional_type.name === item.optional_type.name
+                                  : value.name === item.name;
                         })
                     );
                 });

--- a/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
+++ b/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
@@ -177,9 +177,9 @@ function removeDuplicateVariantTypes(releases: MinecraftRelease[]) {
                         index ===
                         self.findIndex(other => {
                             if (item.name === 'array') {
-                                return other.element_type.name === item.element_type.name;
+                                return other.element_type?.name === item.element_type.name;
                             } else if (item.name === 'optional') {
-                                return other.optional_type.name === item.optional_type.name;
+                                return other.optional_type?.name === item.optional_type.name;
                             } else {
                                 return other.name === item.name;
                             }

--- a/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
+++ b/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
@@ -175,12 +175,14 @@ function removeDuplicateVariantTypes(releases: MinecraftRelease[]) {
                 jsonObject.variant_types = jsonObject.variant_types.filter((item, index, self) => {
                     return (
                         index ===
-                        self.findIndex(value => {
-                            return item.name === 'array'
-                                ? value.element_type.name === item.element_type.name
-                                : item.name === 'optional'
-                                  ? value.optional_type.name === item.optional_type.name
-                                  : value.name === item.name;
+                        self.findIndex(other => {
+                            if (item.name === 'array') {
+                                return other.element_type.name === item.element_type.name;
+                            } else if (item.name === 'optional') {
+                                return other.optional_type.name === item.optional_type.name;
+                            } else {
+                                return other.name === item.name;
+                            }
                         })
                     );
                 });


### PR DESCRIPTION
Wrapper metadata for arrays / optionals was being caught as duplicate by this filter.