### PR TITLE
Add Bedrock GDK paths to core-build-tasks

### DIFF
--- a/change/@minecraft-core-build-tasks-b957c1b3-f0f2-4203-90a8-39d41d9257f4.json
+++ b/change/@minecraft-core-build-tasks-b957c1b3-f0f2-4203-90a8-39d41d9257f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Bedrock GDK paths to core-build-tasks",
+  "packageName": "@minecraft/core-build-tasks",
+  "email": "zachary.campbell@skyboxlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/core-build-tasks/src/platforms/MinecraftProduct.ts
+++ b/tools/core-build-tasks/src/platforms/MinecraftProduct.ts
@@ -5,6 +5,8 @@
  * Non-exhaustive list of product variants used to deploy files to the correct location.
  */
 export enum MinecraftProduct {
+    BedrockGDK = 'BedrockGDK',
+    PreviewGDK = 'PreviewGDK',
     Bedrock = 'BedrockUWP',
     Preview = 'PreviewUWP',
     Custom = 'Custom',

--- a/tools/core-build-tasks/src/tasks/cleanCollateral.ts
+++ b/tools/core-build-tasks/src/tasks/cleanCollateral.ts
@@ -7,6 +7,10 @@ import rimraf from 'rimraf';
 import { getOrThrowFromProcess } from './helpers/getOrThrowFromProcess';
 
 export const STANDARD_CLEAN_PATHS = [
+    'APPDATA/Minecraft Bedrock/Users/Shared/games/com.mojang/development_behavior_packs/PROJECT_NAME',
+    'APPDATA/Minecraft Bedrock/Users/Shared/games/com.mojang/development_resource_packs/PROJECT_NAME',
+    'APPDATA/Minecraft Bedrock Preview/Users/Shared/games/com.mojang/development_behavior_packs/PROJECT_NAME',
+    'APPDATA/Minecraft Bedrock Preview/Users/Shared/games/com.mojang/development_resource_packs/PROJECT_NAME',
     'LOCALAPPDATA/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/development_behavior_packs/PROJECT_NAME',
     'LOCALAPPDATA/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/development_resource_packs/PROJECT_NAME',
     'LOCALAPPDATA/Packages/Microsoft.MinecraftWindowsBeta_8wekyb3d8bbwe/LocalState/games/com.mojang/development_behavior_packs/PROJECT_NAME',

--- a/tools/core-build-tasks/src/tasks/helpers/getGameDeploymentRootPaths.ts
+++ b/tools/core-build-tasks/src/tasks/helpers/getGameDeploymentRootPaths.ts
@@ -7,8 +7,13 @@ import { getOrThrowFromProcess } from './getOrThrowFromProcess';
 
 export function getGameDeploymentRootPaths(): Record<MinecraftProduct, string | undefined> {
     const localAppDataPath = process.env['LOCALAPPDATA'];
+    const appDataPath = process.env['APPDATA'];
     const customDeploymentPath = process.env['CUSTOM_DEPLOYMENT_PATH'];
     return {
+        BedrockGDK: appDataPath ? resolve(appDataPath, 'Minecraft Bedrock/Users/Shared/games/com.mojang/') : undefined,
+        PreviewGDK: appDataPath
+            ? resolve(appDataPath, 'Minecraft Bedrock Preview/Users/Shared/games/com.mojang/')
+            : undefined,
         BedrockUWP: localAppDataPath
             ? resolve(localAppDataPath, 'Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/')
             : undefined,


### PR DESCRIPTION
Support for Minecraft GDK builds with clean/copy tasks when `MINECRAFT_PLATFORM` is set to `BedrockGDK`