### PR TITLE
Removed usage of NPMJS token in release pipeline

### DIFF
--- a/.github/workflows/release-changes.yml
+++ b/.github/workflows/release-changes.yml
@@ -32,7 +32,6 @@ jobs:
       
       # Pass the token on the command line for publishing
       - name: Publish
-        run: npm run release -- --token "$NPM_TOKEN" --yes --new
+        run: npm run release -- --yes --new
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           REPO_PAT: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
Just set up npm OIDC.

https://docs.npmjs.com/trusted-publishers