### PR TITLE
Fix release workflow to support npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-changes.yml
+++ b/.github/workflows/release-changes.yml
@@ -10,15 +10,19 @@ jobs:
     if: github.actor != 'mc-npm'
     environment: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for npm OIDC trusted publishing
+      contents: read # required for actions/checkout
 
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run test:ci # Fully build the repo so we have artifacts available to create releases, include tests so we don't ship in a broken state
       


### PR DESCRIPTION
## Summary

The release workflow's `beachball publish` step has been failing because the npm CLI couldn't complete the OIDC token exchange required by npm's [trusted publishers](https://docs.npmjs.com/trusted-publishers) feature. `beachball publish` is just a wrapper around `npm publish`, so any OIDC requirements need to be satisfied at the workflow level.

This PR makes three changes to `release-changes.yml` so the trusted publishing flow can succeed:

- **Add `permissions: id-token: write`** on the release job. Without this, GitHub Actions never mints the OIDC token and npm falls back to anonymous (causing `ENEEDAUTH` / `E404`). `contents: read` is added for `actions/checkout`.
- **Set `registry-url: 'https://registry.npmjs.org'`** on `actions/setup-node`. This makes `setup-node` generate an `.npmrc` that points npm at the right registry for the OIDC exchange.
- **Bump to `actions/setup-node@v6` with Node 24.** Trusted publishing requires npm ≥ 11.5.1. Node 22 currently ships with npm 10.x; Node 24 ships with npm 11.x, which can perform the OIDC token exchange natively.

## Out-of-band requirements (for reviewers)

For publishing to actually succeed after this change, the following needs to be true on npmjs.com — these can't be expressed in code:

1. Each published package (`@minecraft/api-docs-generator`, `@minecraft/markup-generators-plugin`, `@minecraft/math`, `@minecraft/gameplay-utilities`, etc.) must have a Trusted Publisher entry configured with:
   - Repository: `Mojang/minecraft-scripting-libraries`
   - Workflow filename: `release-changes.yml` (exact, case-sensitive)
   - Environment name: `release`
2. The `release` GitHub Environment must exist in the repo settings (it is already referenced by `environment: release`).

## Testing

Workflow-only change — it will be exercised by the next push to `main` once merged.