### PR TITLE
Update line breaks and links

### DIFF
--- a/change/@minecraft-api-docs-generator-5376add2-ffb9-4bc9-aefe-f28ffb095ad1.json
+++ b/change/@minecraft-api-docs-generator-5376add2-ffb9-4bc9-aefe-f28ffb095ad1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjust @link to always be on the same line as its following value",
+  "packageName": "@minecraft/api-docs-generator",
+  "email": "brandon.chan@skyboxlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@minecraft-markup-generators-plugin-9d453f93-e174-480c-b4eb-eb6965e83036.json
+++ b/change/@minecraft-markup-generators-plugin-9d453f93-e174-480c-b4eb-eb6965e83036.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjust @link to always be on the same line as its following value",
+  "packageName": "@minecraft/markup-generators-plugin",
+  "email": "brandon.chan@skyboxlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8914,7 +8914,7 @@
         },
         "tools/api-docs-generator": {
             "name": "@minecraft/api-docs-generator",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.12.0",
@@ -9136,7 +9136,7 @@
         },
         "tools/markup-generators-plugin": {
             "name": "@minecraft/markup-generators-plugin",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
                 "@rushstack/node-core-library": "^5.14.0",
@@ -9148,7 +9148,7 @@
                 "typescript": "~5.6.0"
             },
             "devDependencies": {
-                "@minecraft/api-docs-generator": "^2.0.1",
+                "@minecraft/api-docs-generator": "^2.0.3",
                 "@minecraft/core-build-tasks": "*",
                 "@types/mustache": "^4.2.2",
                 "@types/node": "^22.0.0",
@@ -9163,7 +9163,7 @@
                 "node": ">=22.0.0"
             },
             "peerDependencies": {
-                "@minecraft/api-docs-generator": "^2.0.1"
+                "@minecraft/api-docs-generator": "^2.0.3"
             }
         },
         "tools/tsconfig": {

--- a/tools/api-docs-generator-test-snapshots/test/changelog_diffing/__snapshots__/changelogDiffing.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/changelog_diffing/__snapshots__/changelogDiffing.spec.ts.snap
@@ -2143,6 +2143,8 @@ description: Contents of the dependant-module module (Version 1.x.x)
 ---
 # \`dependant-module\` Module (Version 1.x.x)
 
+dependant-module has a dependancy on test-module1: [*test-module1*](../../../priorscriptapi/test-module1-1xx/test-module1.md)
+
 > [!IMPORTANT]
 > This documentation is for an older version of this module. Go to the latest documentation [*here*](../../../scriptapi/dependant-module/dependant-module.md).
 
@@ -2203,6 +2205,8 @@ title: dependant-module-2xx Module
 description: Contents of the dependant-module module (Version 2.x.x)
 ---
 # \`dependant-module\` Module (Version 2.x.x)
+
+dependant-module has a dependancy on test-module1: [*test-module1*](../../../scriptapi/test-module1/test-module1.md)
 
 > [!IMPORTANT]
 > This documentation is for an older version of this module. Go to the latest documentation [*here*](../../../scriptapi/dependant-module/dependant-module.md).
@@ -3048,6 +3052,8 @@ title: dependant-module Module
 description: Contents of the dependant-module module
 ---
 # \`dependant-module\` Module
+
+dependant-module has a dependancy on test-module1: [*test-module1*](../../../scriptapi/test-module1/test-module1.md)
 
 ## [Changelog](changelog.md)
 
@@ -4056,6 +4062,8 @@ exports[`Changelog Diffing > Generates correct output for changelog diffs > type
    ***************************************************************************** */
 /**
  * @packageDocumentation
+ * dependant-module has a dependancy on test-module1:
+ * {@link testmodule1}
  *
  * Manifest Details
  * \`\`\`json
@@ -4090,6 +4098,8 @@ exports[`Changelog Diffing > Generates correct output for changelog diffs > type
    ***************************************************************************** */
 /**
  * @packageDocumentation
+ * dependant-module has a dependancy on test-module1:
+ * {@link testmodule1}
  *
  * Manifest Details
  * \`\`\`json
@@ -4126,6 +4136,8 @@ exports[`Changelog Diffing > Generates correct output for changelog diffs > type
    ***************************************************************************** */
 /**
  * @packageDocumentation
+ * dependant-module has a dependancy on test-module1:
+ * {@link testmodule1}
  *
  * Manifest Details
  * \`\`\`json

--- a/tools/api-docs-generator-test-snapshots/test/changelog_diffing/docs/dependant-module/info.json
+++ b/tools/api-docs-generator-test-snapshots/test/changelog_diffing/docs/dependant-module/info.json
@@ -1,0 +1,3 @@
+{
+  "description": "dependant-module has a dependancy on test-module1: {@link test-module1}"
+}

--- a/tools/api-docs-generator-test-snapshots/test/type_linking/__snapshots__/typeLinking.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/type_linking/__snapshots__/typeLinking.spec.ts.snap
@@ -826,13 +826,13 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * Example class property: {@link ExampleClass.ExampleProperty}
  * Example class method: {@link ExampleClass.ExampleMethod}
  * Example interface: {@link ExampleInterface}
- * Example interface property: {@link
- * ExampleInterface.ExampleProperty}
+ * Example interface property:
+ * {@link ExampleInterface.ExampleProperty}
  * Example enum: {@link ExampleEnum}
  * Example enum value: {@link ExampleEnum.ExampleValue}
- * This line has multiple links! {@link
- * @minecraft/example-module} {@link ExampleFunction} {@link
- * ExampleConstant} {@link ExampleObject}
+ * This line has multiple links!
+ * {@link @minecraft/example-module} {@link ExampleFunction}
+ * {@link ExampleConstant} {@link ExampleObject}
  *
  * Manifest Details
  * \`\`\`json
@@ -918,13 +918,13 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * Example class property: {@link ExampleClass.ExampleProperty}
  * Example class method: {@link ExampleClass.ExampleMethod}
  * Example interface: {@link ExampleInterface}
- * Example interface property: {@link
- * ExampleInterface.ExampleProperty}
+ * Example interface property:
+ * {@link ExampleInterface.ExampleProperty}
  * Example enum: {@link ExampleEnum}
  * Example enum value: {@link ExampleEnum.ExampleValue}
- * This line has multiple links! {@link
- * @minecraft/example-module} {@link ExampleFunction} {@link
- * ExampleConstant} {@link ExampleObject}
+ * This line has multiple links!
+ * {@link @minecraft/example-module} {@link ExampleFunction}
+ * {@link ExampleConstant} {@link ExampleObject}
  *
  * Manifest Details
  * \`\`\`json
@@ -1004,24 +1004,24 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * This is a description with a ton of links from a dependency
  * module:
  * Example module: {@link minecraftexamplemodule}
- * Example module function: {@link
- * minecraftexamplemodule#ExampleFunction}
- * Example module constant: {@link
- * minecraftexamplemodule#ExampleConstant}
- * Example module object: {@link
- * minecraftexamplemodule#ExampleObject}
+ * Example module function:
+ * {@link minecraftexamplemodule#ExampleFunction}
+ * Example module constant:
+ * {@link minecraftexamplemodule#ExampleConstant}
+ * Example module object:
+ * {@link minecraftexamplemodule#ExampleObject}
  * Example class: {@link minecraftexamplemodule.ExampleClass}
- * Example class property: {@link
- * minecraftexamplemodule.ExampleClass.ExampleProperty}
- * Example class method: {@link
- * minecraftexamplemodule.ExampleClass.ExampleMethod}
- * Example interface: {@link
- * minecraftexamplemodule.ExampleInterface}
- * Example interface property: {@link
- * minecraftexamplemodule.ExampleInterface.ExampleProperty}
+ * Example class property:
+ * {@link minecraftexamplemodule.ExampleClass.ExampleProperty}
+ * Example class method:
+ * {@link minecraftexamplemodule.ExampleClass.ExampleMethod}
+ * Example interface:
+ * {@link minecraftexamplemodule.ExampleInterface}
+ * Example interface property:
+ * {@link minecraftexamplemodule.ExampleInterface.ExampleProperty}
  * Example enum: {@link minecraftexamplemodule.ExampleEnum}
- * Example enum value: {@link
- * minecraftexamplemodule.ExampleEnum.ExampleValue}
+ * Example enum value:
+ * {@link minecraftexamplemodule.ExampleEnum.ExampleValue}
  *
  * Manifest Details
  * \`\`\`json
@@ -2262,13 +2262,13 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * Example class property: {@link ExampleClass.ExampleProperty}
  * Example class method: {@link ExampleClass.ExampleMethod}
  * Example interface: {@link ExampleInterface}
- * Example interface property: {@link
- * ExampleInterface.ExampleProperty}
+ * Example interface property:
+ * {@link ExampleInterface.ExampleProperty}
  * Example enum: {@link ExampleEnum}
  * Example enum value: {@link ExampleEnum.ExampleValue}
- * This line has multiple links! {@link
- * @minecraft/example-module} {@link ExampleFunction} {@link
- * ExampleConstant} {@link ExampleObject}
+ * This line has multiple links!
+ * {@link @minecraft/example-module} {@link ExampleFunction}
+ * {@link ExampleConstant} {@link ExampleObject}
  *
  * Manifest Details
  * \`\`\`json
@@ -2354,13 +2354,13 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * Example class property: {@link ExampleClass.ExampleProperty}
  * Example class method: {@link ExampleClass.ExampleMethod}
  * Example interface: {@link ExampleInterface}
- * Example interface property: {@link
- * ExampleInterface.ExampleProperty}
+ * Example interface property:
+ * {@link ExampleInterface.ExampleProperty}
  * Example enum: {@link ExampleEnum}
  * Example enum value: {@link ExampleEnum.ExampleValue}
- * This line has multiple links! {@link
- * @minecraft/example-module} {@link ExampleFunction} {@link
- * ExampleConstant} {@link ExampleObject}
+ * This line has multiple links!
+ * {@link @minecraft/example-module} {@link ExampleFunction}
+ * {@link ExampleConstant} {@link ExampleObject}
  *
  * Manifest Details
  * \`\`\`json
@@ -2440,24 +2440,24 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * This is a description with a ton of links from a dependency
  * module:
  * Example module: {@link minecraftexamplemodule}
- * Example module function: {@link
- * minecraftexamplemodule#ExampleFunction}
- * Example module constant: {@link
- * minecraftexamplemodule#ExampleConstant}
- * Example module object: {@link
- * minecraftexamplemodule#ExampleObject}
+ * Example module function:
+ * {@link minecraftexamplemodule#ExampleFunction}
+ * Example module constant:
+ * {@link minecraftexamplemodule#ExampleConstant}
+ * Example module object:
+ * {@link minecraftexamplemodule#ExampleObject}
  * Example class: {@link minecraftexamplemodule.ExampleClass}
- * Example class property: {@link
- * minecraftexamplemodule.ExampleClass.ExampleProperty}
- * Example class method: {@link
- * minecraftexamplemodule.ExampleClass.ExampleMethod}
- * Example interface: {@link
- * minecraftexamplemodule.ExampleInterface}
- * Example interface property: {@link
- * minecraftexamplemodule.ExampleInterface.ExampleProperty}
+ * Example class property:
+ * {@link minecraftexamplemodule.ExampleClass.ExampleProperty}
+ * Example class method:
+ * {@link minecraftexamplemodule.ExampleClass.ExampleMethod}
+ * Example interface:
+ * {@link minecraftexamplemodule.ExampleInterface}
+ * Example interface property:
+ * {@link minecraftexamplemodule.ExampleInterface.ExampleProperty}
  * Example enum: {@link minecraftexamplemodule.ExampleEnum}
- * Example enum value: {@link
- * minecraftexamplemodule.ExampleEnum.ExampleValue}
+ * Example enum value:
+ * {@link minecraftexamplemodule.ExampleEnum.ExampleValue}
  *
  * Manifest Details
  * \`\`\`json

--- a/tools/api-docs-generator-test-snapshots/test/type_linking/__snapshots__/typeLinking.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/type_linking/__snapshots__/typeLinking.spec.ts.snap
@@ -468,6 +468,8 @@ Example enum: [*@minecraft/example-module.ExampleEnum*](../../../scriptapi/minec
 
 Example enum value: [*@minecraft/example-module.ExampleEnum.ExampleValue*](../../../scriptapi/minecraft/example-module/ExampleEnum.md#examplevalue)
 
+This line has multiple links and lots of text! This is the first link [*@minecraft/example-module*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md), and this is the second. [*@minecraft/example-module.ExampleFunction*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md#examplefunction) Here's a third link [*@minecraft/example-module.ExampleConstant*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md#exampleconstant) and this one here is the final link [*@minecraft/example-module.ExampleObject*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md#exampleobject)
+
 ## [Changelog](changelog.md)
 
 ## Manifest Details
@@ -1022,6 +1024,13 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * Example enum: {@link minecraftexamplemodule.ExampleEnum}
  * Example enum value:
  * {@link minecraftexamplemodule.ExampleEnum.ExampleValue}
+ * This line has multiple links and lots of text! This is the
+ * first link {@link minecraftexamplemodule}, and this is the
+ * second. {@link minecraftexamplemodule#ExampleFunction}
+ * Here's a third link
+ * {@link minecraftexamplemodule#ExampleConstant} and this one
+ * here is the final link
+ * {@link minecraftexamplemodule#ExampleObject}
  *
  * Manifest Details
  * \`\`\`json
@@ -1657,6 +1666,8 @@ Example interface property: [*@minecraft/example-module.ExampleInterface.Example
 Example enum: [*@minecraft/example-module.ExampleEnum*](../../../scriptapi/minecraft/example-module/ExampleEnum.md)
 
 Example enum value: [*@minecraft/example-module.ExampleEnum.ExampleValue*](../../../scriptapi/minecraft/example-module/ExampleEnum.md#examplevalue)
+
+This line has multiple links and lots of text! This is the first link [*@minecraft/example-module*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md), and this is the second. [*@minecraft/example-module.ExampleFunction*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md#examplefunction) Here's a third link [*@minecraft/example-module.ExampleConstant*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md#exampleconstant) and this one here is the final link [*@minecraft/example-module.ExampleObject*](../../../scriptapi/minecraft/example-module/minecraft-example-module.md#exampleobject)
 
 ## [Changelog](changelog.md)
 
@@ -2458,6 +2469,13 @@ exports[`Type Linking > Properly generates documentation for types that are link
  * Example enum: {@link minecraftexamplemodule.ExampleEnum}
  * Example enum value:
  * {@link minecraftexamplemodule.ExampleEnum.ExampleValue}
+ * This line has multiple links and lots of text! This is the
+ * first link {@link minecraftexamplemodule}, and this is the
+ * second. {@link minecraftexamplemodule#ExampleFunction}
+ * Here's a third link
+ * {@link minecraftexamplemodule#ExampleConstant} and this one
+ * here is the final link
+ * {@link minecraftexamplemodule#ExampleObject}
  *
  * Manifest Details
  * \`\`\`json

--- a/tools/api-docs-generator-test-snapshots/test/type_linking/docs/@minecraft/example-module-2/info.json
+++ b/tools/api-docs-generator-test-snapshots/test/type_linking/docs/@minecraft/example-module-2/info.json
@@ -11,6 +11,7 @@
     "Example interface: {@link @minecraft/example-module.ExampleInterface}",
     "Example interface property: {@link @minecraft/example-module.ExampleInterface.ExampleProperty}",
     "Example enum: {@link @minecraft/example-module.ExampleEnum}",
-    "Example enum value: {@link @minecraft/example-module.ExampleEnum.ExampleValue}"
+    "Example enum value: {@link @minecraft/example-module.ExampleEnum.ExampleValue}",
+    "This line has multiple links and lots of text! This is the first link {@link @minecraft/example-module}, and this is the second. {@link @minecraft/example-module.ExampleFunction} Here's a third link {@link @minecraft/example-module.ExampleConstant} and this one here is the final link {@link @minecraft/example-module.ExampleObject}"
   ]
 }

--- a/tools/api-docs-generator/package.json
+++ b/tools/api-docs-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minecraft/api-docs-generator",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "Core Minecraft API Docs Generator package for generating API markup and documentation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -1745,6 +1745,10 @@ function boundChanges(releases: MinecraftRelease[]) {
                                 continue;
                             }
 
+                            if (!validOld && !validNew) {
+                                continue;
+                            }
+
                             const validOldMin = details.$old.min_value !== undefined;
                             const validOldMax = details.$old.max_value !== undefined;
 

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -428,11 +428,11 @@ function addDescriptionFields(
     const originalValue = LINK_TAG.concat(' ');
     const tempValue = LINK_TAG.concat('-');
     for (let line of tsDescription) {
-        line = line.replace(originalValue, tempValue);
+        line = line.replaceAll(originalValue, tempValue);
 
         const wrappedLines = wrap(line, { width: 60, indent: '', trim: true });
         for (let wrappedBreaks of wrappedLines.split('\n')) {
-            wrappedBreaks = wrappedBreaks.replace(tempValue, originalValue);
+            wrappedBreaks = wrappedBreaks.replaceAll(tempValue, originalValue);
             tsDescriptionWrapped.push(wrappedBreaks);
         }
     }

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -1725,10 +1725,6 @@ function boundChanges(releases: MinecraftRelease[]) {
                                 continue;
                             }
 
-                            if (!validOld && !validNew) {
-                                continue;
-                            }
-
                             const validOldMin = details.$old.min_value !== undefined;
                             const validOldMax = details.$old.max_value !== undefined;
 

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -430,10 +430,11 @@ function addDescriptionFields(
     for (let line of tsDescription) {
         line = line.replace(originalValue, tempValue);
 
-        let wrappedLines = wrap(line, { width: 60, indent: '', trim: true });
-        wrappedLines = line.replace(tempValue, originalValue);
-
-        tsDescriptionWrapped.push(...wrappedLines.split('\n'));
+        const wrappedLines = wrap(line, { width: 60, indent: '', trim: true });
+        for (let wrappedBreaks of wrappedLines.split('\n')) {
+            wrappedBreaks = wrappedBreaks.replace(tempValue, originalValue);
+            tsDescriptionWrapped.push(wrappedBreaks);
+        }
     }
 
     jsonObject[`${descriptionKey}_ts`] = tsDescriptionWrapped;

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -425,36 +425,15 @@ function addDescriptionFields(
     const tsDescription = linkSymbols(description, generateTSDocsLink, moduleJson, allModules);
     const tsDescriptionWrapped: string[] = [];
 
-    const maxLineWidth = 60;
-    const linkStart = '{'.concat(LINK_TAG);
-    for (const line of tsDescription) {
-        let newLine = '';
-        let isPrevWordLinking = false;
-        for (let word of line.split(' ')) {
-            if (isPrevWordLinking) {
-                word = linkStart.concat(' ').concat(word);
-            }
+    const originalValue = LINK_TAG.concat(' ');
+    const tempValue = LINK_TAG.concat('-');
+    for (let line of tsDescription) {
+        line = line.replace(originalValue, tempValue);
 
-            if (word === linkStart) {
-                isPrevWordLinking = true;
-                continue;
-            }
+        let wrappedLines = wrap(line, { width: 60, indent: '', trim: true });
+        wrappedLines = line.replace(tempValue, originalValue);
 
-            if (newLine.length + 1 + word.length <= maxLineWidth) {
-                if (newLine.length > 0) {
-                    newLine = newLine.concat(' ');
-                }
-                newLine = newLine.concat(word);
-            } else {
-                if (newLine.length > 0) {
-                    tsDescriptionWrapped.push(newLine);
-                }
-                newLine = word;
-            }
-
-            isPrevWordLinking = false;
-        }
-        tsDescriptionWrapped.push(newLine);
+        tsDescriptionWrapped.push(...wrappedLines.split('\n'));
     }
 
     jsonObject[`${descriptionKey}_ts`] = tsDescriptionWrapped;

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -424,10 +424,37 @@ function addDescriptionFields(
 
     const tsDescription = linkSymbols(description, generateTSDocsLink, moduleJson, allModules);
     const tsDescriptionWrapped: string[] = [];
+
+    const maxLineWidth = 60;
+    const linkStart = '{'.concat(LINK_TAG);
     for (const line of tsDescription) {
-        const wrappedLines = wrap(line, { width: 60, indent: '', trim: true });
-        tsDescriptionWrapped.push(...wrappedLines.split('\n'));
+        let newLine = '';
+        let isPrevWordLinking = false;
+        for (let word of line.split(' ')) {
+            if (isPrevWordLinking) {
+                word = linkStart.concat(' ').concat(word);
+            }
+
+            if (word === linkStart) {
+                isPrevWordLinking = true;
+                continue;
+            }
+
+            if (newLine.length + 1 + word.length <= maxLineWidth) {
+                if (newLine.length > 0) {
+                    newLine = newLine.concat(' ');
+                }
+                newLine = newLine.concat(word);
+            } else {
+                tsDescriptionWrapped.push(newLine);
+                newLine = word;
+            }
+
+            isPrevWordLinking = false;
+        }
+        tsDescriptionWrapped.push(newLine);
     }
+
     jsonObject[`${descriptionKey}_ts`] = tsDescriptionWrapped;
 }
 

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -446,7 +446,9 @@ function addDescriptionFields(
                 }
                 newLine = newLine.concat(word);
             } else {
-                tsDescriptionWrapped.push(newLine);
+                if (newLine.length > 0) {
+                    tsDescriptionWrapped.push(newLine);
+                }
                 newLine = word;
             }
 

--- a/tools/markup-generators-plugin/package.json
+++ b/tools/markup-generators-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minecraft/markup-generators-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Plugin for @minecraft/api-docs-generator containing core markup generators and template files",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -40,7 +40,7 @@
     "CHANGELOG.*"
   ],
   "devDependencies": {
-    "@minecraft/api-docs-generator": "^2.0.1",
+    "@minecraft/api-docs-generator": "^2.0.3",
     "@minecraft/core-build-tasks": "*",
     "@types/mustache": "^4.2.2",
     "@types/node": "^22.0.0",
@@ -61,6 +61,6 @@
     "typescript": "~5.6.0"
   },
   "peerDependencies": {
-    "@minecraft/api-docs-generator": "^2.0.1"
+    "@minecraft/api-docs-generator": "^2.0.3"
   }
 }


### PR DESCRIPTION
Update to prevent @ link in generated .d.ts and the following type name within the same brace from being on separate lines