### PR TITLE
Fix null error in bound function

### DIFF
--- a/change/@minecraft-api-docs-generator-5d4b32f2-294e-4bb1-a1c4-56519494fd5b.json
+++ b/change/@minecraft-api-docs-generator-5d4b32f2-294e-4bb1-a1c4-56519494fd5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix null issues in bound function",
+  "packageName": "@minecraft/api-docs-generator",
+  "email": "mike.demone@skyboxlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/api-docs-generator-test-snapshots/test/bounds/__snapshots__/bounds.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/__snapshots__/bounds.spec.ts.snap
@@ -115,7 +115,7 @@ Notes:
 
 ### **methodThatTakesBoundedValue**
 \`
-methodThatTakesBoundedValue(s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number): void
+methodThatTakesBoundedValue(s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, null_details_to_no_details: number): void
 \`
 
 #### **Parameters**
@@ -133,6 +133,7 @@ methodThatTakesBoundedValue(s: number, t: number, u: number, v: number, w: numbe
 - **y**: *number*
   * Maximum Bound: \`255\`
 - **z**: *number*
+- **null_details_to_no_details**: *number*
 
 **Returns** *void*
   
@@ -314,7 +315,7 @@ Notes:
 
 ### **methodThatTakesBoundedValue**
 \`
-methodThatTakesBoundedValue(s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number): void
+methodThatTakesBoundedValue(s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, null_details_to_no_details: number): void
 \`
 
 #### **Parameters**
@@ -332,6 +333,7 @@ methodThatTakesBoundedValue(s: number, t: number, u: number, v: number, w: numbe
   * Minimum Bound: \`1\`
 - **z**: *number*
   * Bounds: [\`1\`, \`255\`]
+- **null_details_to_no_details**: *number*
 
 **Returns** *void*
   
@@ -561,7 +563,8 @@ export class ClassWithBounds {
         w: number,
         x: number,
         y: number,
-        z: number
+        z: number,
+        null_details_to_no_details: number
     ): void;
 }
 
@@ -683,7 +686,8 @@ export class ClassWithBounds {
         w: number,
         x: number,
         y: number,
-        z: number
+        z: number,
+        null_details_to_no_details: number
     ): void;
 }
 

--- a/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v1.json
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v1.json
@@ -306,6 +306,19 @@
                                     "min": -2147483648
                                 }
                             }
+                        },                                               
+                        {
+                            "name": "null_details_to_no_details",
+                            "details": null,
+                            "type": {
+                                "is_bind_type": false,
+                                "is_errorable": false,
+                                "name": "int32",
+                                "valid_range": {
+                                    "max": 2147483647,
+                                    "min": -2147483648
+                                }
+                            }
                         }
                     ],
                     "is_constructor": false,

--- a/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v2.json
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v2.json
@@ -305,6 +305,18 @@
                                     "min": -2147483648
                                 }
                             }
+                        },                      
+                        {
+                            "name": "null_details_to_no_details",
+                            "type": {
+                                "is_bind_type": false,
+                                "is_errorable": false,
+                                "name": "int32",
+                                "valid_range": {
+                                    "max": 2147483647,
+                                    "min": -2147483648
+                                }
+                            }
                         }
                     ],
                     "is_constructor": false,

--- a/tools/api-docs-generator/src/changelog.ts
+++ b/tools/api-docs-generator/src/changelog.ts
@@ -594,8 +594,7 @@ export class ChangelogGenerator {
 
                 // Serialize once, parse N times — avoids re-running JSON.stringify per module.
                 const serializedChangelog = JSON.stringify(sortedChangelogs, (_key, value: unknown) =>
-                    // eslint-disable-next-line unicorn/no-null
-                    typeof value === 'undefined' ? null : value
+                    typeof value === 'undefined' ? undefined : value
                 );
                 for (const moduleJson of currentModuleList) {
                     const moduleWithChangelog = moduleJson as ModuleWithChangelog<


### PR DESCRIPTION
**Issue**
Running the generator with certain configurations caused null reference exceptions within the `boundChanges` Common Filter.

**Cause**
This PR caused the value `undefined` to be turned into null when being serialized in a changelog: https://github.com/Mojang/minecraft-scripting-libraries/commit/8de3a55dad1570a702540c0ab642559cc02c63dc

**Fix**
Serialize fields that are 'undefined' as undefined instead of null.