### PR TITLE
Added array and string max length to documentation+changelogs

### DIFF
--- a/change/@minecraft-api-docs-generator-d5c15644-fc50-4ab1-b265-91ce1b2caef6.json
+++ b/change/@minecraft-api-docs-generator-d5c15644-fc50-4ab1-b265-91ce1b2caef6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Document maximum lengths for array and string properties, including changelog updates",
+  "packageName": "@minecraft/api-docs-generator",
+  "email": "jake@xbox.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@minecraft-markup-generators-plugin-6fbb127e-be55-47b9-90b3-e0f18f18dd1a.json
+++ b/change/@minecraft-markup-generators-plugin-6fbb127e-be55-47b9-90b3-e0f18f18dd1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Document maximum lengths for array and string properties, including changelog updates",
+  "packageName": "@minecraft/markup-generators-plugin",
+  "email": "jake@xbox.com",
+  "dependentChangeType": "patch"
+}

--- a/tools/api-docs-generator-test-snapshots/test/bounds/__snapshots__/bounds.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/__snapshots__/bounds.spec.ts.snap
@@ -540,21 +540,21 @@ export class ClassWithBounds {
     addedMaxLength: string;
     /**
      * @remarks
-     * This property can't be used in restricted-execution mode.
+     * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
      * Maximum Length: 0
      */
     limitedArray: number[];
     /**
      * @remarks
-     * This property can't be used in restricted-execution mode.
+     * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
      * Maximum Length: 50
      */
     limitedString: string;
     /**
      * @remarks
-     * This property can't be used in restricted-execution mode.
+     * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
      * Bounds: [0, 0]
      */
@@ -684,20 +684,20 @@ export class ClassWithBounds {
     addedMaxLength: string;
     /**
      * @remarks
-     * This property can't be used in restricted-execution mode.
+     * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
      */
     limitedArray: number[];
     /**
      * @remarks
-     * This property can't be used in restricted-execution mode.
+     * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
      * Maximum Length: 75
      */
     limitedString: string;
     /**
      * @remarks
-     * This property can't be used in restricted-execution mode.
+     * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
      * Bounds: [0, 0]
      */

--- a/tools/api-docs-generator-test-snapshots/test/bounds/__snapshots__/bounds.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/__snapshots__/bounds.spec.ts.snap
@@ -31,6 +31,32 @@ description: Contents of the bounds-module.ClassWithBounds class (Version 1.x.x)
 
 ## Properties
 
+### **addedMaxLength**
+\`addedMaxLength: string;\`
+
+Type: *string*
+
+Notes:
+  - This property can't be used in restricted-execution mode.
+
+### **limitedArray**
+\`limitedArray: number[];\`
+
+Type: *number*[]
+
+Notes:
+  - This property has a maximum length of \`0\`
+  - This property can't be used in restricted-execution mode.
+
+### **limitedString**
+\`limitedString: string;\`
+
+Type: *string*
+
+Notes:
+  - This property has a maximum length of \`50\`
+  - This property can't be used in restricted-execution mode.
+
 ### **r**
 \`r: number;\`
 
@@ -231,6 +257,32 @@ description: Contents of the bounds-module.ClassWithBounds class.
 
 ## Properties
 
+### **addedMaxLength**
+\`addedMaxLength: string;\`
+
+Type: *string*
+
+Notes:
+  - This property has a maximum length of \`25\`
+  - This property can't be used in restricted-execution mode.
+
+### **limitedArray**
+\`limitedArray: number[];\`
+
+Type: *number*[]
+
+Notes:
+  - This property can't be used in restricted-execution mode.
+
+### **limitedString**
+\`limitedString: string;\`
+
+Type: *string*
+
+Notes:
+  - This property has a maximum length of \`75\`
+  - This property can't be used in restricted-execution mode.
+
 ### **r**
 \`r: number;\`
 
@@ -424,6 +476,9 @@ description: Changelog of the \`bounds-module\` module
 
 ## 2.0.0
 #### Changed *[\`ClassWithBounds\`](ClassWithBounds.md)*
+- Added maximum length of \`25\` for property *[\`addedMaxLength\`](ClassWithBounds.md#addedmaxlength)*
+- Removed maximum length for property *[\`limitedArray\`](ClassWithBounds.md#limitedarray)*
+- Changed maximum length of \`50\` to \`75\` for property *[\`limitedString\`](ClassWithBounds.md#limitedstring)*
 - Changed minimum bound of \`-255\` to \`1\` for property *[\`s\`](ClassWithBounds.md#s)* 
 - Changed maximum bound of \`1\` to \`255\` for property *[\`t\`](ClassWithBounds.md#t)* 
 - Changed minimum bound of \`-255\` to \`1\` for property *[\`v\`](ClassWithBounds.md#v)* 
@@ -480,6 +535,26 @@ export class ClassWithBounds {
     /**
      * @remarks
      * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
+     *
+     */
+    addedMaxLength: string;
+    /**
+     * @remarks
+     * This property can't be used in restricted-execution mode.
+     *
+     * Maximum Length: 0
+     */
+    limitedArray: number[];
+    /**
+     * @remarks
+     * This property can't be used in restricted-execution mode.
+     *
+     * Maximum Length: 50
+     */
+    limitedString: string;
+    /**
+     * @remarks
+     * This property can't be used in restricted-execution mode.
      *
      * Bounds: [0, 0]
      */
@@ -603,6 +678,26 @@ export class ClassWithBounds {
     /**
      * @remarks
      * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
+     *
+     * Maximum Length: 25
+     */
+    addedMaxLength: string;
+    /**
+     * @remarks
+     * This property can't be used in restricted-execution mode.
+     *
+     */
+    limitedArray: number[];
+    /**
+     * @remarks
+     * This property can't be used in restricted-execution mode.
+     *
+     * Maximum Length: 75
+     */
+    limitedString: string;
+    /**
+     * @remarks
+     * This property can't be used in restricted-execution mode.
      *
      * Bounds: [0, 0]
      */

--- a/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v1.json
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v1.json
@@ -45,6 +45,43 @@
                 {
                     "is_baked": false,
                     "is_read_only": false,
+                    "max_length": 50,
+                    "name": "limitedString",
+                    "type": {
+                        "is_bind_type": false,
+                        "is_errorable": false,
+                        "name": "string"
+                    }
+                },
+                {
+                    "is_baked": false,
+                    "is_read_only": false,
+                    "max_length": 0,
+                    "name": "limitedArray",
+                    "type": {
+                        "element_type": {
+                            "is_bind_type": false,
+                            "is_errorable": false,
+                            "name": "int32"
+                        },
+                        "is_bind_type": false,
+                        "is_errorable": false,
+                        "name": "array"
+                    }
+                },
+                {
+                    "is_baked": false,
+                    "is_read_only": false,
+                    "name": "addedMaxLength",
+                    "type": {
+                        "is_bind_type": false,
+                        "is_errorable": false,
+                        "name": "string"
+                    }
+                },
+                {
+                    "is_baked": false,
+                    "is_read_only": false,
                     "min_value": 0,
                     "max_value": 0,
                     "name": "r",

--- a/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v2.json
+++ b/tools/api-docs-generator-test-snapshots/test/bounds/input/test-module_v2.json
@@ -45,6 +45,43 @@
                 {
                     "is_baked": false,
                     "is_read_only": false,
+                    "max_length": 75,
+                    "name": "limitedString",
+                    "type": {
+                        "is_bind_type": false,
+                        "is_errorable": false,
+                        "name": "string"
+                    }
+                },
+                {
+                    "is_baked": false,
+                    "is_read_only": false,
+                    "name": "limitedArray",
+                    "type": {
+                        "element_type": {
+                            "is_bind_type": false,
+                            "is_errorable": false,
+                            "name": "int32"
+                        },
+                        "is_bind_type": false,
+                        "is_errorable": false,
+                        "name": "array"
+                    }
+                },
+                {
+                    "is_baked": false,
+                    "is_read_only": false,
+                    "max_length": 25,
+                    "name": "addedMaxLength",
+                    "type": {
+                        "is_bind_type": false,
+                        "is_errorable": false,
+                        "name": "string"
+                    }
+                },
+                {
+                    "is_baked": false,
+                    "is_read_only": false,
                     "min_value": 0,
                     "max_value": 0,
                     "name": "r",

--- a/tools/api-docs-generator-test-snapshots/test/changelog_diffing/__snapshots__/changelogDiffing.spec.ts.snap
+++ b/tools/api-docs-generator-test-snapshots/test/changelog_diffing/__snapshots__/changelogDiffing.spec.ts.snap
@@ -224,6 +224,11 @@ exports[`Changelog Diffing > Generates correct output for changelog diffs > chan
         "properties": [
           {
             "is_read_only": false,
+            "max_length": {
+              "$old": 10,
+              "$new": 20,
+              "$changed": true
+            },
             "name": "exampleProperty",
             "type": {
               "is_bind_type": false,
@@ -1327,6 +1332,7 @@ exports[`Changelog Diffing > Generates correct output for changelog diffs > chan
         "properties": [
           {
             "is_read_only": false,
+            "max_length": 10,
             "name": "exampleProperty",
             "type": {
               "is_bind_type": false,
@@ -2762,6 +2768,7 @@ description: Contents of the test-module1.SmallClass class (Version 1.x.x).
 Type: *string*
 
 Notes:
+  - This property has a maximum length of \`10\`
   - This property can't be used in restricted-execution mode.
   - This property can throw errors when used.
 "
@@ -3687,6 +3694,7 @@ description: Contents of the test-module1.SmallClass class.
 Type: *string*
 
 Notes:
+  - This property has a maximum length of \`20\`
   - This property can't be used in restricted-execution mode.
   - This property can throw errors when used.
 "
@@ -3758,6 +3766,8 @@ description: Changelog of the \`test-module1\` module
   - Removed argument \`removedArg\`
 - Changed function *[\`testMethodWithRemovedErrorable\`](ExampleClass1.md#testmethodwithremovederrorable)*
   - Changed return type from *boolean* (throws exceptions) to *boolean*
+#### Changed *[\`SmallClass\`](SmallClass.md)*
+- Changed maximum length of \`10\` to \`20\` for property *[\`exampleProperty\`](SmallClass.md#exampleproperty)*
 #### Changed function \`testFunctionWithAddedArgument\`
 - Added argument \`addedArg\`
 #### Changed function \`testFunctionWithAddedErrorable\`
@@ -3996,6 +4006,7 @@ exports[`Changelog Diffing > Generates correct output for changelog diffs > txt/
       - Removed argument \`removedArg\`
     - Changed function \`testMethodWithRemovedErrorable\`
       - Changed return type from \`*boolean*\` (throws exceptions) to \`*boolean*\`
+- Changed class \`SmallClass\`
 - Added interface \`AddedInterface\`
   \`\`\`ts
   export interface AddedInterface {
@@ -4431,6 +4442,7 @@ export class SmallClass {
      * @remarks
      * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
+     * Maximum Length: 10
      * @throws This property can throw when used.
      */
     exampleProperty: string;
@@ -4751,6 +4763,7 @@ export class SmallClass {
      * @remarks
      * @privilege restricted-execution-unusable - This property can't be used in restricted-execution mode.
      *
+     * Maximum Length: 20
      * @throws This property can throw when used.
      */
     exampleProperty: string;

--- a/tools/api-docs-generator-test-snapshots/test/changelog_diffing/input/test-module_v1.json
+++ b/tools/api-docs-generator-test-snapshots/test/changelog_diffing/input/test-module_v1.json
@@ -56,6 +56,7 @@
       "properties": [
         {
           "is_read_only": false,
+          "max_length": 10,
           "name": "exampleProperty",
           "type": {
             "is_bind_type": false,

--- a/tools/api-docs-generator-test-snapshots/test/changelog_diffing/input/test-module_v2.json
+++ b/tools/api-docs-generator-test-snapshots/test/changelog_diffing/input/test-module_v2.json
@@ -56,6 +56,7 @@
       "properties": [
         {
           "is_read_only": false,
+          "max_length": 20,
           "name": "exampleProperty",
           "type": {
             "is_bind_type": false,

--- a/tools/api-docs-generator/src/changelog.ts
+++ b/tools/api-docs-generator/src/changelog.ts
@@ -91,6 +91,7 @@ const scriptingDataLayout: RootMetadataScope = {
                         is_read_only: { type: 'value' },
                         min_value: { type: 'value' },
                         max_value: { type: 'value' },
+                        max_length: { type: 'value' },
                         get_privilege: { type: 'array', key: 'name' },
                         set_privilege: { type: 'array', key: 'name' },
                         type: TypeDataLayout,

--- a/tools/api-docs-generator/src/filters/CommonFilters.ts
+++ b/tools/api-docs-generator/src/filters/CommonFilters.ts
@@ -1619,6 +1619,10 @@ function boundValues(releases: MinecraftRelease[]) {
                 }
 
                 for (const propertyJson of concatJson.properties ?? []) {
+                    if (typeof propertyJson.max_length === 'number') {
+                        propertyJson.has_max_length = true;
+                    }
+
                     if (propertyJson.min_value !== undefined) {
                         propertyJson.has_minimum = true;
                     }
@@ -1688,6 +1692,24 @@ function boundChanges(releases: MinecraftRelease[]) {
                                 propertyJson.max_added = true;
                             } else if (validOld && !validNew) {
                                 propertyJson.max_removed = true;
+                            }
+                        }
+
+                        const maxLength = propertyJson.max_length as unknown as {
+                            $old: unknown;
+                            $new: unknown;
+                        };
+
+                        if (maxLength) {
+                            const validOld = typeof maxLength.$old === 'number';
+                            const validNew = typeof maxLength.$new === 'number';
+
+                            if (validOld && validNew && maxLength.$old !== maxLength.$new) {
+                                propertyJson.max_length_changed = true;
+                            } else if (!validOld && validNew) {
+                                propertyJson.max_length_added = true;
+                            } else if (validOld && !validNew) {
+                                propertyJson.max_length_removed = true;
                             }
                         }
                     }

--- a/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
+++ b/tools/api-docs-generator/src/filters/TypeScriptFilters.ts
@@ -330,6 +330,7 @@ function flagTSComments(obj: MarkupCommentFlags): void {
         obj.has_minimum ||
         obj.has_maximum ||
         obj.has_bounds ||
+        obj.has_max_length ||
         obj.has_errors ||
         obj.is_prerelease ||
         obj.is_deprecated ||
@@ -356,6 +357,7 @@ function flagTSComments(obj: MarkupCommentFlags): void {
         obj.has_minimum ||
         obj.has_maximum ||
         obj.has_bounds ||
+        obj.has_max_length ||
         obj.has_errors
     ) {
         obj.msdocs_has_comments = true;

--- a/tools/api-docs-generator/src/modules/MinecraftScriptModule.ts
+++ b/tools/api-docs-generator/src/modules/MinecraftScriptModule.ts
@@ -56,6 +56,7 @@ export const MarkupCommentFlagsValidator = Intersect(
         has_minimum: Optional(Boolean),
         has_maximum: Optional(Boolean),
         has_bounds: Optional(Boolean),
+        has_max_length: Optional(Boolean),
         has_errors: Optional(Boolean),
 
         prerelease: Optional(String),
@@ -355,6 +356,10 @@ export const MinecraftPropertyRecord = Intersect(
         max_added: Optional(Boolean),
         max_changed: Optional(Boolean),
         max_removed: Optional(Boolean),
+        max_length: Optional(Number.Or(Null)),
+        max_length_added: Optional(Boolean),
+        max_length_changed: Optional(Boolean),
+        max_length_removed: Optional(Boolean),
 
         // Runtime Markup
         property_name: Optional(String.Or(Null)),

--- a/tools/markup-generators-plugin/templates/msdocs/script/module_changelog.mustache
+++ b/tools/markup-generators-plugin/templates/msdocs/script/module_changelog.mustache
@@ -108,7 +108,16 @@ description: Changelog of the `{{{name}}}` module
     {{/max_changed}}
     {{#max_removed}}
 - Removed maximum bound for *[`{{{name}}}`]({{class_name}}.md#{{bookmark_name}})*
-    {{/max_removed}}       
+    {{/max_removed}}
+    {{#max_length_added}}
+- Added maximum length of `{{{max_length.$new}}}` for property *[`{{{name}}}`]({{class_name}}.md#{{bookmark_name}})*
+    {{/max_length_added}}
+    {{#max_length_changed}}
+- Changed maximum length of `{{{max_length.$old}}}` to `{{{max_length.$new}}}` for property *[`{{{name}}}`]({{class_name}}.md#{{bookmark_name}})*
+    {{/max_length_changed}}
+    {{#max_length_removed}}
+- Removed maximum length for property *[`{{{name}}}`]({{class_name}}.md#{{bookmark_name}})*
+    {{/max_length_removed}}
       {{#type}}
         {{#$changed}}
 - Changed type for *[`{{{name}}}`]({{class_name}}.md#{{bookmark_name}})* from {{#$old.type}}{{> type_with_links}}{{#is_errorable}} (throws exceptions){{/is_errorable}}{{/$old.type}} to {{#$new.type}}{{> type_with_links}}{{#is_errorable}} (throws exceptions){{/is_errorable}}{{/$new.type}}

--- a/tools/markup-generators-plugin/templates/msdocs/script/property.mustache
+++ b/tools/markup-generators-plugin/templates/msdocs/script/property.mustache
@@ -37,6 +37,9 @@ Notes:
   - This property has a maximum bound of `{{max_value}}`
     {{/has_maximum}}
   {{/has_bounds}}
+  {{#has_max_length}}
+  - This property has a maximum length of `{{max_length}}`
+  {{/has_max_length}}
   {{#set_disallowed_in_restricted_execution}}
     {{#get_disallowed_in_restricted_execution}}
   - This property can't be used in restricted-execution mode.

--- a/tools/markup-generators-plugin/templates/tsdef/property.mustache
+++ b/tools/markup-generators-plugin/templates/tsdef/property.mustache
@@ -77,6 +77,9 @@
  * Maximum Value: {{max_value}}
     {{/has_maximum}}
   {{/has_bounds}}
+  {{#has_max_length}}
+ * Maximum Length: {{max_length}}
+  {{/has_max_length}}
  {{#throws_description_ts.length}}
  * @throws
    {{#throws_description_ts}}


### PR DESCRIPTION
Recently added max length constraints for strings and realized this metadata was missing.